### PR TITLE
Add initial VBscript to JS transpiling support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ install:
 - npm ci
 script:
 - npm install codecov -g
+- npm run compile
 - npm run test
 after_success:
 - codecov

--- a/lib/scripting/.gitignore
+++ b/lib/scripting/.gitignore
@@ -1,2 +1,1 @@
-estree.js
-vbscript.js
+vbscript.ts

--- a/lib/scripting/.gitignore
+++ b/lib/scripting/.gitignore
@@ -1,0 +1,2 @@
+estree.js
+vbscript.js

--- a/lib/scripting/estree.ts
+++ b/lib/scripting/estree.ts
@@ -17,7 +17,37 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { CallExpression, ExpressionStatement, Literal, Program, VariableDeclaration, VariableDeclarator } from 'estree';
+import {
+	EmptyStatement,
+	Literal,
+	Program,
+	Statement,
+	UnaryExpression,
+	VariableDeclaration,
+	VariableDeclarator,
+} from 'estree';
+
+export function emptyStatement(): EmptyStatement {
+	return {
+		type: 'EmptyStatement',
+	};
+}
+
+export function literal(data: any): Literal {
+	return {
+		type: 'Literal',
+		value: data,
+	};
+}
+
+export function unaryExpression(data: any): UnaryExpression {
+	return {
+		type: 'UnaryExpression',
+		operator: data[0],
+		prefix: true,
+		argument: data[1],
+	};
+}
 
 /**
  * Returns the root node.
@@ -39,7 +69,7 @@ export function varDecl(data: [string, null, string, string[]]): VariableDeclara
 	return {
 		type: 'VariableDeclaration',
 		kind: 'let',
-		declarations: [ data[2], ...data[3] ].map((item) => {
+		declarations: [data[2], ...data[3]].map(item => {
 			return variableDeclarator(item);
 		}),
 	};
@@ -49,7 +79,7 @@ export function variableDeclarator(name: string, value: any = null): VariableDec
 	return {
 		type: 'VariableDeclarator',
 		id: { type: 'Identifier', name },
-		init: value ? literal(value) : null,
+		init: value ? value : null,
 	};
 }
 
@@ -60,24 +90,20 @@ export function constDecl(data: any): VariableDeclaration {
 	return {
 		type: 'VariableDeclaration',
 		kind: 'const',
-		declarations: [ data[2], ...data[3] ].map((item: any[]) => {
+		declarations: [data[2], ...data[3]].map((item: any[]) => {
 			return variableDeclarator(item[0], item[4]);
 		}),
 	};
 }
 
-export function literal(data: any): Literal {
+/**
+ * Returns a subCall Statement.
+ */
+
+export function subCallStmt(data: any): Statement {
 	return {
-		type: 'Literal',
-		value: data,
-	};
-}
-
-export function expressionStatement(data: any): ExpressionStatement {
-	let expression: CallExpression;
-
-	if (data.length > 1) {
-		expression = {
+		type: 'ExpressionStatement',
+		expression: {
 			type: 'CallExpression',
 			callee: {
 				type: 'MemberExpression',
@@ -87,25 +113,11 @@ export function expressionStatement(data: any): ExpressionStatement {
 				},
 				property: {
 					type: 'Identifier',
-					name: data[1][0],
+					name: data[0][1],
 				},
 				computed: false,
 			},
-			arguments: [],
-		};
-	} else {
-		expression = {
-			type: 'CallExpression',
-			callee: {
-				type: 'Identifier',
-				name: data[0][0],
-			},
-			arguments: [],
-		};
-	}
-
-	return {
-		type: 'ExpressionStatement',
-		expression,
+			arguments: data.length > 1 ? [data[2], ...data[4]] : [],
+		},
 	};
 }

--- a/lib/scripting/estree.ts
+++ b/lib/scripting/estree.ts
@@ -1,0 +1,51 @@
+/*
+ * VPDB - Virtual Pinball Database
+ * Copyright (C) 2019 freezy <freezy@vpdb.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { Program, VariableDeclaration, VariableDeclarator } from 'estree';
+
+/**
+ * Returns the root node.
+ * @param data List of `GlobalStmt` nodes
+ */
+export function program(data: any): Program {
+	return {
+		type: 'Program',
+		sourceType: 'script',
+		body: data,
+	};
+}
+
+/**
+ * Returns a variable declaration.
+ * @param data Result of the `"Dim" __ VarName OtherVarsOpt:* NL` rule.
+ */
+export function varDecl(data: [string, null, string, string[]]): VariableDeclaration {
+	return {
+		type: 'VariableDeclaration',
+		kind: 'let',
+		declarations: [ data[2], ...data[3] ].map(variableDeclarator),
+	};
+}
+
+export function variableDeclarator(name: string): VariableDeclarator {
+	return {
+		type: 'VariableDeclarator',
+		id: { type: 'Identifier', name },
+	};
+}

--- a/lib/scripting/estree.ts
+++ b/lib/scripting/estree.ts
@@ -17,7 +17,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { Literal, Program, VariableDeclaration, VariableDeclarator  } from 'estree';
+import { CallExpression, ExpressionStatement, Literal, Program, VariableDeclaration, VariableDeclarator } from 'estree';
 
 /**
  * Returns the root node.
@@ -70,5 +70,42 @@ export function literal(data: any): Literal {
 	return {
 		type: 'Literal',
 		value: data,
+	};
+}
+
+export function expressionStatement(data: any): ExpressionStatement {
+	let expression: CallExpression;
+
+	if (data.length > 1) {
+		expression = {
+			type: 'CallExpression',
+			callee: {
+				type: 'MemberExpression',
+				object: {
+					type: 'Identifier',
+					name: data[0][0],
+				},
+				property: {
+					type: 'Identifier',
+					name: data[1][0],
+				},
+				computed: false,
+			},
+			arguments: [],
+		};
+	} else {
+		expression = {
+			type: 'CallExpression',
+			callee: {
+				type: 'Identifier',
+				name: data[0][0],
+			},
+			arguments: [],
+		};
+	}
+
+	return {
+		type: 'ExpressionStatement',
+		expression,
 	};
 }

--- a/lib/scripting/estree.ts
+++ b/lib/scripting/estree.ts
@@ -17,7 +17,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { Program, VariableDeclaration, VariableDeclarator } from 'estree';
+import { Literal, Program, VariableDeclaration, VariableDeclarator  } from 'estree';
 
 /**
  * Returns the root node.
@@ -47,5 +47,29 @@ export function variableDeclarator(name: string): VariableDeclarator {
 	return {
 		type: 'VariableDeclarator',
 		id: { type: 'Identifier', name },
+	};
+}
+
+/**
+ * Returns a constant declaration.
+ */
+export function constDecl(data: any): VariableDeclaration {
+	const name: string = data[2][0];
+
+	return {
+		type: 'VariableDeclaration',
+		kind: 'const',
+		declarations: [ {
+			type: 'VariableDeclarator',
+			id: { type: 'Identifier', name },
+			init: literal(data[2][4]),
+		}],
+	};
+}
+
+export function literal(data: any): Literal {
+	return {
+		type: 'Literal',
+		value: data,
 	};
 }

--- a/lib/scripting/estree.ts
+++ b/lib/scripting/estree.ts
@@ -39,14 +39,17 @@ export function varDecl(data: [string, null, string, string[]]): VariableDeclara
 	return {
 		type: 'VariableDeclaration',
 		kind: 'let',
-		declarations: [ data[2], ...data[3] ].map(variableDeclarator),
+		declarations: [ data[2], ...data[3] ].map((item) => {
+			return variableDeclarator(item);
+		}),
 	};
 }
 
-export function variableDeclarator(name: string): VariableDeclarator {
+export function variableDeclarator(name: string, value: any = null): VariableDeclarator {
 	return {
 		type: 'VariableDeclarator',
 		id: { type: 'Identifier', name },
+		init: value ? literal(value) : null,
 	};
 }
 
@@ -54,16 +57,12 @@ export function variableDeclarator(name: string): VariableDeclarator {
  * Returns a constant declaration.
  */
 export function constDecl(data: any): VariableDeclaration {
-	const name: string = data[2][0];
-
 	return {
 		type: 'VariableDeclaration',
 		kind: 'const',
-		declarations: [ {
-			type: 'VariableDeclarator',
-			id: { type: 'Identifier', name },
-			init: literal(data[2][4]),
-		}],
+		declarations: [ data[2], ...data[3] ].map((item: any[]) => {
+			return variableDeclarator(item[0], item[4]);
+		}),
 	};
 }
 

--- a/lib/scripting/post-process.ts
+++ b/lib/scripting/post-process.ts
@@ -20,7 +20,7 @@
 import { Literal, MemberExpression, UnaryExpression } from 'estree';
 import { inspect } from 'util';
 
-import * as estree from './estree';
+import * as estree from './estree'; // use the namespace to avoid clashes
 
 /**
  * Grammar:
@@ -83,7 +83,7 @@ type ConstDeclResult = [ string, null, string, null, Literal ];
  * null,
  * [ { type: 'UnaryExpression', operator: '-', prefix: true, argument: { type: 'Literal', value: 2 } } ]
  * ```
- * @todo UnaryExpression will be more than that in the future!
+ * @todo Literal and UnaryExpression will be more generic in the future!
  */
 export function subCallStmt(result: [ MemberExpression, null, Literal?, null?, UnaryExpression[]? ]) {
 	const callee = result[0];

--- a/lib/scripting/post-process.ts
+++ b/lib/scripting/post-process.ts
@@ -1,0 +1,103 @@
+/*
+ * VPDB - Virtual Pinball Database
+ * Copyright (C) 2019 freezy <freezy@vpdb.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { Literal, MemberExpression, UnaryExpression } from 'estree';
+import { inspect } from 'util';
+
+import * as estree from './estree';
+
+/**
+ * Grammar:
+ * ```
+ * VarDecl -> "Dim" __ VarName OtherVarsOpt:* NL
+ * ```
+ * Example: `Dim test1, test2, test3\n`
+ * Result: `'Dim', null, 'test1', [ 'test2', 'test3' ], [ [ [ '\n' ] ] ]`
+ */
+export function varDecl(result: [ string, null, string, string[] ]) {
+	const firstName = result[2];
+	const otherNames = result[3];
+	return estree.variableDeclaration(
+		'let',
+		[firstName, ...otherNames].map(name => [ name, null ]), // can't assign values with Dim
+	);
+}
+
+/**
+ * Grammar:
+ * ```
+ * ConstDecl -> "Const" __ ConstNameValue OtherConstantsOpt:* NL
+ * ```
+ * Example: `Const test1 = 3.14, test2 = 4, test3 = "TEST", test4 = -5.2\n`
+ * Result:
+ * ```
+ * 'Const',
+ * null,
+ * [ 'test1', null, '=', null, { type: 'Literal', value: 3.14 } ],
+ * [
+ *   [ 'test2', null, '=', null, { type: 'Literal', value: 4 } ],
+ *   [ 'test3', null, '=', null, { type: 'Literal', value: 'TEST' } ],
+ *   [ 'test4', null, '=', null, { type: 'Literal', value: -5.2 } ]
+ * ],
+ * [ [ [ '\n' ] ] ]
+ * ```
+ */
+export function constDecl(result: [ string, null, ConstDeclResult, ConstDeclResult[] ]) {
+	const firstDecl = result[2];
+	const otherDecls = result[3];
+	const decls: ConstDeclResult[] = [firstDecl, ...otherDecls];
+	return estree.variableDeclaration(
+		'const',
+		decls.map((decl: ConstDeclResult) => [ decl[0], decl[4] ]),
+	);
+}
+type ConstDeclResult = [ string, null, string, null, Literal ];
+
+/**
+ * Grammar:
+ * ```
+ * SubCallStmt -> QualifiedID __ SubSafeExprOpt _ CommaExprList:*
+ * ```
+ * Example: `BallRelease.KickBall 0, -2\n`
+ * Result:
+ * ```
+ * { type: 'MemberExpression', object: { type: 'Identifier', name: 'BallRelease' }, property: { type: 'Identifier', name: 'KickBall' }, computed: false },
+ * null,
+ * { type: 'Literal', value: 0 },
+ * null,
+ * [ { type: 'UnaryExpression', operator: '-', prefix: true, argument: { type: 'Literal', value: 2 } } ]
+ * ```
+ * @todo UnaryExpression will be more than that in the future!
+ */
+export function subCallStmt(result: [ MemberExpression, null, Literal?, null?, UnaryExpression[]? ]) {
+	const callee = result[0];
+	const firstArg = result[2] ? [ result[2] ] : []; // array, so we can easily spread below
+	const otherArgs = result[4] || [];
+	return estree.callExpressionStatement(callee, [ ...firstArg, ...otherArgs] );
+}
+
+/**
+ * This just prints out what's given.
+ * @example `debug(arguments);`
+ * @param x anything
+ */
+function debug(x: any) {
+	// tslint:disable-next-line:no-console
+	return console.log(inspect(x, { depth: null, colors: true }));
+}

--- a/lib/scripting/transpile.spec.ts
+++ b/lib/scripting/transpile.spec.ts
@@ -22,16 +22,27 @@ import { vbsToJs } from './transpile';
 
 describe('The VBScript transpiler', () => {
 
-	it('should transpile a variable declaration', () => {
+	it('should transpile a single variable declaration', () => {
+		const vbs = `Dim test1\n`;
+		const js = vbsToJs(vbs);
+		expect(js).to.equal('let test1;\n');
+	});
 
+	it('should transpile a multiple variable declaration', () => {
 		const vbs = `Dim test1, test2, test3\n`;
 		const js = vbsToJs(vbs);
 		expect(js).to.equal('let test1, test2, test3;\n');
 	});
 
-	it('should transpile a const declaration', () => {
+	it('should transpile a single Const declaration', () => {
 		const vbs = `Const pi = 3.14\n`;
 		const js = vbsToJs(vbs);
 		expect(js).to.equal('const pi = 3.14;\n');
+	});
+
+	it('should transpile a multiple Const declaration', () => {
+		const vbs = `Const test1 = 3.14, test2 = 4, test3 = "TEST", test4 = -5.2\n`;
+		const js = vbsToJs(vbs);
+		expect(js).to.equal('const test1 = 3.14, test2 = 4, test3 = "TEST", test4 = -5.2;\n');
 	});
 });

--- a/lib/scripting/transpile.spec.ts
+++ b/lib/scripting/transpile.spec.ts
@@ -21,7 +21,6 @@ import { expect } from 'chai';
 import { vbsToJs } from './transpile';
 
 describe('The VBScript transpiler', () => {
-
 	it('should transpile a single variable declaration', () => {
 		const vbs = `Dim test1\n`;
 		const js = vbsToJs(vbs);
@@ -46,9 +45,15 @@ describe('The VBScript transpiler', () => {
 		expect(js).to.equal('const test1 = 3.14, test2 = 4, test3 = "TEST", test4 = -5.2;\n');
 	});
 
-	it('should transpile a simple function call', () => {
+	it('should transpile a subcall statement without params', () => {
 		const vbs = `BallRelease.CreateBall\n`;
 		const js = vbsToJs(vbs);
 		expect(js).to.equal('BallRelease.CreateBall();\n');
+	});
+
+	it('should transpile a subcall statement with params', () => {
+		const vbs = `BallRelease.KickBall 0, -2\n`;
+		const js = vbsToJs(vbs);
+		expect(js).to.equal('BallRelease.KickBall(0, -2);\n');
 	});
 });

--- a/lib/scripting/transpile.spec.ts
+++ b/lib/scripting/transpile.spec.ts
@@ -45,4 +45,10 @@ describe('The VBScript transpiler', () => {
 		const js = vbsToJs(vbs);
 		expect(js).to.equal('const test1 = 3.14, test2 = 4, test3 = "TEST", test4 = -5.2;\n');
 	});
+
+	it('should transpile a simple function call', () => {
+		const vbs = `BallRelease.CreateBall\n`;
+		const js = vbsToJs(vbs);
+		expect(js).to.equal('BallRelease.CreateBall();\n');
+	});
 });

--- a/lib/scripting/transpile.spec.ts
+++ b/lib/scripting/transpile.spec.ts
@@ -1,0 +1,31 @@
+/*
+ * VPDB - Virtual Pinball Database
+ * Copyright (C) 2019 freezy <freezy@vpdb.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { expect } from 'chai';
+import { vbsToJs } from './transpile';
+
+describe('The VBScript transpiler', () => {
+
+	it('should transpile a variable declaration', () => {
+
+		const vbs = `Dim test1, test2, test3\n`;
+		const js = vbsToJs(vbs);
+		expect(js).to.equal('let test1, test2, test3;\n');
+	});
+});

--- a/lib/scripting/transpile.spec.ts
+++ b/lib/scripting/transpile.spec.ts
@@ -28,4 +28,10 @@ describe('The VBScript transpiler', () => {
 		const js = vbsToJs(vbs);
 		expect(js).to.equal('let test1, test2, test3;\n');
 	});
+
+	it('should transpile a const declaration', () => {
+		const vbs = `Const pi = 3.14\n`;
+		const js = vbsToJs(vbs);
+		expect(js).to.equal('const pi = 3.14;\n');
+	});
 });

--- a/lib/scripting/transpile.ts
+++ b/lib/scripting/transpile.ts
@@ -28,6 +28,7 @@ const vbsGrammar = require('./vbscript.js');
 export function vbsToJs(vbs: string): string {
 	const parser = new Parser(Grammar.fromCompiled(vbsGrammar));
 	parser.feed(vbs);
+	/* istanbul ignore if */
 	if (parser.results.length === 0) {
 		throw new Error('Parser returned no results.');
 	}

--- a/lib/scripting/transpile.ts
+++ b/lib/scripting/transpile.ts
@@ -1,0 +1,35 @@
+/*
+ * VPDB - Virtual Pinball Database
+ * Copyright (C) 2019 freezy <freezy@vpdb.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { generate } from 'astring';
+import { Grammar, Parser } from 'nearley';
+
+const vbsGrammar = require('./vbscript.js');
+
+/**
+ * A function that transpiles VBScript to JavaScript.
+ */
+export function vbsToJs(vbs: string): string {
+	const parser = new Parser(Grammar.fromCompiled(vbsGrammar));
+	parser.feed(vbs);
+	if (parser.results.length === 0) {
+		throw new Error('Parser returned no results.');
+	}
+	return generate(parser.results[0]);
+}

--- a/lib/scripting/transpile.ts
+++ b/lib/scripting/transpile.ts
@@ -19,8 +19,7 @@
 
 import { generate } from 'astring';
 import { Grammar, Parser } from 'nearley';
-
-const vbsGrammar = require('./vbscript.js');
+import * as vbsGrammar from './vbscript';
 
 /**
  * A function that transpiles VBScript to JavaScript.

--- a/lib/scripting/vbscript.bnf
+++ b/lib/scripting/vbscript.bnf
@@ -1,0 +1,740 @@
+!===============================
+! VB Script grammar.
+!
+! To create the grammar I was using Microsoft's VB Script documentation
+! available from http://msdn.microsoft.com/scripting,
+! VB Script parser from ArrowHead project http://www.tripi.com/arrowhead/,
+! and Visual Basic .Net grammar file written by Devin Cook.
+!
+! This grammar cannot cover all aspects of VBScript and may have some errors.
+! Feel free to contact me if you find any flaws in the grammar.
+!
+! Vladimir Morozov   vmoroz@hotmail.com
+!
+! Special thanks to Nathan Baulch for the grammar updates.
+!
+! USE GOLD PARSER BUILDER VERSION 2.1 AND LATER TO COMPILE THIS GRAMMAR.
+!===============================
+
+"Name"            = 'VB Script'
+"Author"          = 'John G. Kemeny and Thomas E. Kurtz'
+"Version"         = '5.0'
+"About"           = 'VB Script grammar.'
+"Case Sensitive"  = False
+"Start Symbol"    = <Program>
+
+!===============================
+! Character sets
+!===============================
+
+{String Char}   = {All Valid} - ["]
+{Date Char}     = {Printable} - [#]
+{ID Name Char}  = {Printable} - ['['']']
+{Hex Digit}     = {Digit} + [abcdef]
+{Oct Digit}     = [01234567]
+{WS}            = {Whitespace} - {CR} - {LF}
+{ID Tail}       = {Alphanumeric} + [_]
+
+!===============================
+! Terminals
+!===============================
+
+NewLine        = {CR} {LF}
+               | {CR}
+               | {LF}
+               | ':'
+
+! Special white space definition. Whitespace is either space or tab, which
+! can be followed by continuation symbol '_' followed by new line character
+Whitespace     = {WS}+
+               | '_' {WS}* {CR}? {LF}?
+
+! Special comment definition
+Comment Line   = ''
+               | 'Rem'
+
+! Literals
+StringLiteral  = '"' ( {String Char} | '""' )* '"'
+IntLiteral     = {Digit}+
+HexLiteral     = '&H' {Hex Digit}+ '&'?
+OctLiteral     = '&' {Oct Digit}+ '&'?
+FloatLiteral   = {Digit}* '.' {Digit}+ ( 'E' [+-]? {Digit}+ )?
+               | {Digit}+ 'E' [+-]? {Digit}+
+DateLiteral    = '#' {Date Char}+ '#'
+
+! Identifier is either starts with letter and followed by letter,
+! number or underscore, or it can be escaped sequence of any printable
+! characters ([] and [_$% :-) @] are valid identifiers)
+ID             = {Letter} {ID Tail}*
+               | '[' {ID Name Char}* ']'
+
+! White space is not allowed to be before dot, but allowed to be after it.
+IDDot          = {Letter} {ID Tail}* '.'
+               | '[' {ID Name Char}* ']' '.'
+               | 'And.'
+               | 'ByRef.'
+               | 'ByVal.'
+               | 'Call.'
+               | 'Case.'
+               | 'Class.'
+               | 'Const.'
+               | 'Default.'
+               | 'Dim.'
+               | 'Do.'
+               | 'Each.'
+               | 'Else.'
+               | 'ElseIf.'
+               | 'Empty.'
+               | 'End.'
+               | 'Eqv.'
+               | 'Erase.'
+               | 'Error.'
+               | 'Exit.'
+               | 'Explicit.'
+               | 'False.'
+               | 'For.'
+               | 'Function.'
+               | 'Get.'
+               | 'GoTo.'
+               | 'If.'
+               | 'Imp.'
+               | 'In.'
+               | 'Is.'
+               | 'Let.'
+               | 'Loop.'
+               | 'Mod.'
+               | 'New.'
+               | 'Next.'
+               | 'Not.'
+               | 'Nothing.'
+               | 'Null.'
+               | 'On.'
+               | 'Option.'
+               | 'Or.'
+               | 'Preserve.'
+               | 'Private.'
+               | 'Property.'
+               | 'Public.'
+               | 'Redim.'
+               | 'Rem.'
+               | 'Resume.'
+               | 'Select.'
+               | 'Set.'
+               | 'Step.'
+               | 'Sub.'
+               | 'Then.'
+               | 'To.'
+               | 'True.'
+               | 'Until.'
+               | 'WEnd.'
+               | 'While.'
+               | 'With.'
+               | 'Xor.'
+
+! The following identifiers should only be used in With statement.
+! This rule must be checked by contextual analyzer.
+DotID          = '.' {Letter} {ID Tail}*
+               | '.' '[' {ID Name Char}* ']'
+               | '.And'
+               | '.ByRef'
+               | '.ByVal'
+               | '.Call'
+               | '.Case'
+               | '.Class'
+               | '.Const'
+               | '.Default'
+               | '.Dim'
+               | '.Do'
+               | '.Each'
+               | '.Else'
+               | '.ElseIf'
+               | '.Empty'
+               | '.End'
+               | '.Eqv'
+               | '.Erase'
+               | '.Error'
+               | '.Exit'
+               | '.Explicit'
+               | '.False'
+               | '.For'
+               | '.Function'
+               | '.Get'
+               | '.GoTo'
+               | '.If'
+               | '.Imp'
+               | '.In'
+               | '.Is'
+               | '.Let'
+               | '.Loop'
+               | '.Mod'
+               | '.New'
+               | '.Next'
+               | '.Not'
+               | '.Nothing'
+               | '.Null'
+               | '.On'
+               | '.Option'
+               | '.Or'
+               | '.Preserve'
+               | '.Private'
+               | '.Property'
+               | '.Public'
+               | '.Redim'
+               | '.Rem'
+               | '.Resume'
+               | '.Select'
+               | '.Set'
+               | '.Step'
+               | '.Sub'
+               | '.Then'
+               | '.To'
+               | '.True'
+               | '.Until'
+               | '.WEnd'
+               | '.While'
+               | '.With'
+               | '.Xor'
+
+DotIDDot       = '.' {Letter}{ID Tail}* '.'
+               | '.' '[' {ID Name Char}* ']' '.'
+               | '.And.'
+               | '.ByRef.'
+               | '.ByVal.'
+               | '.Call.'
+               | '.Case.'
+               | '.Class.'
+               | '.Const.'
+               | '.Default.'
+               | '.Dim.'
+               | '.Do.'
+               | '.Each.'
+               | '.Else.'
+               | '.ElseIf.'
+               | '.Empty.'
+               | '.End.'
+               | '.Eqv.'
+               | '.Erase.'
+               | '.Error.'
+               | '.Exit.'
+               | '.Explicit.'
+               | '.False.'
+               | '.For.'
+               | '.Function.'
+               | '.Get.'
+               | '.GoTo.'
+               | '.If.'
+               | '.Imp.'
+               | '.In.'
+               | '.Is.'
+               | '.Let.'
+               | '.Loop.'
+               | '.Mod.'
+               | '.New.'
+               | '.Next.'
+               | '.Not.'
+               | '.Nothing.'
+               | '.Null.'
+               | '.On.'
+               | '.Option.'
+               | '.Or.'
+               | '.Preserve.'
+               | '.Private.'
+               | '.Property.'
+               | '.Public.'
+               | '.Redim.'
+               | '.Rem.'
+               | '.Resume.'
+               | '.Select.'
+               | '.Set.'
+               | '.Step.'
+               | '.Sub.'
+               | '.Then.'
+               | '.To.'
+               | '.True.'
+               | '.Until.'
+               | '.WEnd.'
+               | '.While.'
+               | '.With.'
+               | '.Xor.'
+
+!===============================
+! Rules
+!===============================
+
+<NL>                   ::= NewLine <NL>
+                         | NewLine
+
+<Program>              ::= <NLOpt> <GlobalStmtList>
+
+!===============================
+! Rules : Declarations
+!===============================
+
+<ClassDecl>            ::= 'Class' <ExtendedID> <NL> <MemberDeclList> 'End' 'Class' <NL>
+
+<MemberDeclList>       ::= <MemberDecl> <MemberDeclList>
+                         | null
+
+<MemberDecl>           ::= <FieldDecl>
+                         | <VarDecl>
+                         | <ConstDecl>
+                         | <SubDecl>
+                         | <FunctionDecl>
+                         | <PropertyDecl>
+
+<FieldDecl>            ::= 'Private' <FieldName> <OtherVarsOpt> <NL>
+                         | 'Public' <FieldName> <OtherVarsOpt> <NL>
+
+<FieldName>            ::= <FieldID> '(' <ArrayRankList> ')'
+                         | <FieldID>
+
+<FieldID>              ::= ID
+                         | 'Default'
+                         | 'Erase'
+                         | 'Error'
+                         | 'Explicit'
+                         | 'Step'
+
+<VarDecl>              ::= 'Dim' <VarName> <OtherVarsOpt> <NL>
+
+<VarName>              ::= <ExtendedID> '(' <ArrayRankList> ')'
+                         | <ExtendedID>
+
+<OtherVarsOpt>         ::= ',' <VarName> <OtherVarsOpt>
+                         |
+
+<ArrayRankList>        ::= <IntLiteral> ',' <ArrayRankList>
+                         | <IntLiteral>
+                         |
+
+<ConstDecl>            ::= <AccessModifierOpt> 'Const' <ConstList> <NL>
+
+<ConstList>            ::= <ExtendedID> '=' <ConstExprDef> ',' <ConstList>
+                         | <ExtendedID> '=' <ConstExprDef>
+
+<ConstExprDef>         ::= '(' <ConstExprDef> ')'
+                         | '-' <ConstExprDef>
+                         | '+' <ConstExprDef>
+                         | <ConstExpr>
+
+<SubDecl>              ::= <MethodAccessOpt> 'Sub' <ExtendedID> <MethodArgList> <NL> <MethodStmtList> 'End' 'Sub' <NL>
+                         | <MethodAccessOpt> 'Sub' <ExtendedID> <MethodArgList> <InlineStmt> 'End' 'Sub' <NL>
+
+<FunctionDecl>         ::= <MethodAccessOpt> 'Function' <ExtendedID> <MethodArgList> <NL> <MethodStmtList> 'End' 'Function' <NL>
+                         | <MethodAccessOpt> 'Function' <ExtendedID> <MethodArgList> <InlineStmt> 'End' 'Function' <NL>
+
+<MethodAccessOpt>      ::= 'Public' 'Default'
+                         | <AccessModifierOpt>
+
+<AccessModifierOpt>    ::= 'Public'
+                         | 'Private'
+                         |
+
+<MethodArgList>        ::= '(' <ArgList> ')'
+                         | '(' ')'
+                         |
+
+<ArgList>              ::= <Arg> ',' <ArgList>
+                         | <Arg>
+
+<Arg>                  ::= <ArgModifierOpt> <ExtendedID> '(' ')'
+                         | <ArgModifierOpt> <ExtendedID>
+
+<ArgModifierOpt>       ::= 'ByVal'
+                         | 'ByRef'
+                         |
+
+<PropertyDecl>         ::= <MethodAccessOpt> 'Property' <PropertyAccessType> <ExtendedID> <MethodArgList> <NL> <MethodStmtList> 'End' 'Property' <NL>
+
+<PropertyAccessType>   ::= 'Get'
+                         | 'Let'
+                         | 'Set'
+
+!===============================
+! Rules : Statements
+!===============================
+
+<GlobalStmt>           ::= <OptionExplicit>
+                         | <ClassDecl>
+                         | <FieldDecl>
+                         | <ConstDecl>
+                         | <SubDecl>
+                         | <FunctionDecl>
+                         | <BlockStmt>
+
+<MethodStmt>           ::= <ConstDecl>
+                         | <BlockStmt>
+
+<BlockStmt>            ::= <VarDecl>
+                         | <RedimStmt>
+                         | <IfStmt>
+                         | <WithStmt>
+                         | <SelectStmt>
+                         | <LoopStmt>
+                         | <ForStmt>
+                         | <InlineStmt> <NL>
+
+<InlineStmt>           ::= <AssignStmt>
+                         | <CallStmt>
+                         | <SubCallStmt>
+                         | <ErrorStmt>
+                         | <ExitStmt>
+                         | 'Erase' <ExtendedID>
+
+<GlobalStmtList>       ::= <GlobalStmt> <GlobalStmtList>
+                         |
+
+<MethodStmtList>       ::= <MethodStmt> <MethodStmtList>
+                         |
+
+<BlockStmtList>        ::= <BlockStmt> <BlockStmtList>
+                         |
+
+<OptionExplicit>       ::= 'Option' 'Explicit' <NL>
+
+<ErrorStmt>            ::= 'On' 'Error' 'Resume' 'Next'
+                         | 'On' 'Error' 'GoTo' IntLiteral  ! must be 0
+
+<ExitStmt>             ::= 'Exit' 'Do'
+                         | 'Exit' 'For'
+                         | 'Exit' 'Function'
+                         | 'Exit' 'Property'
+                         | 'Exit' 'Sub'
+
+<AssignStmt>           ::= <LeftExpr> '=' <Expr>
+                         | 'Set' <LeftExpr> '=' <Expr>
+                         | 'Set' <LeftExpr> '=' 'New' <LeftExpr>
+
+! Hack: VB Script allows to have construct a = b = c, which means a = (b = c)
+! In this grammar we do not allow it in order to prevent complications with
+! interpretation of a(1) = 2, which may be considered as array element assignment
+! or a subroutine call: a ((1) = 2).
+! Note: VBScript allows to have missed parameters: a ,,2,3,
+! VM: If somebody knows a better way to do it, please let me know
+<SubCallStmt>          ::= <QualifiedID> <SubSafeExprOpt> <CommaExprList>
+                         | <QualifiedID> <SubSafeExprOpt>
+                         | <QualifiedID> '(' <Expr> ')' <CommaExprList>
+                         | <QualifiedID> '(' <Expr> ')'
+                         | <QualifiedID> '(' ')'
+                         | <QualifiedID> <IndexOrParamsList> '.' <LeftExprTail> <SubSafeExprOpt> <CommaExprList>
+                         | <QualifiedID> <IndexOrParamsListDot> <LeftExprTail> <SubSafeExprOpt> <CommaExprList>
+                         | <QualifiedID> <IndexOrParamsList> '.' <LeftExprTail> <SubSafeExprOpt>
+                         | <QualifiedID> <IndexOrParamsListDot> <LeftExprTail> <SubSafeExprOpt>
+
+! This very simplified case - the problem is that we cannot use parenthesis in aaa(bbb).ccc (ddd)
+<SubSafeExprOpt>       ::= <SubSafeExpr>
+                         |
+
+<CallStmt>             ::= 'Call' <LeftExpr>
+
+<LeftExpr>             ::= <QualifiedID> <IndexOrParamsList> '.' <LeftExprTail>
+                         | <QualifiedID> <IndexOrParamsListDot> <LeftExprTail>
+                         | <QualifiedID> <IndexOrParamsList>
+                         | <QualifiedID>
+                         | <SafeKeywordID>
+
+<LeftExprTail>         ::= <QualifiedIDTail> <IndexOrParamsList> '.' <LeftExprTail>
+                         | <QualifiedIDTail> <IndexOrParamsListDot> <LeftExprTail>
+                         | <QualifiedIDTail> <IndexOrParamsList>
+                         | <QualifiedIDTail>
+
+! VB Script does not allow to have space between Identifier and dot:
+! a . b - Error ; a. b or a.b - OK
+<QualifiedID>          ::= IDDot <QualifiedIDTail>
+                         | DotIDDot <QualifiedIDTail>
+                         | ID
+                         | DotID
+
+<QualifiedIDTail>      ::= IDDot <QualifiedIDTail>
+                         | ID
+                         | <KeywordID>
+
+<KeywordID>            ::= <SafeKeywordID>
+                         | 'And'
+                         | 'ByRef'
+                         | 'ByVal'
+                         | 'Call'
+                         | 'Case'
+                         | 'Class'
+                         | 'Const'
+                         | 'Dim'
+                         | 'Do'
+                         | 'Each'
+                         | 'Else'
+                         | 'ElseIf'
+                         | 'Empty'
+                         | 'End'
+                         | 'Eqv'
+                         | 'Exit'
+                         | 'False'
+                         | 'For'
+                         | 'Function'
+                         | 'Get'
+                         | 'GoTo'
+                         | 'If'
+                         | 'Imp'
+                         | 'In'
+                         | 'Is'
+                         | 'Let'
+                         | 'Loop'
+                         | 'Mod'
+                         | 'New'
+                         | 'Next'
+                         | 'Not'
+                         | 'Nothing'
+                         | 'Null'
+                         | 'On'
+                         | 'Option'
+                         | 'Or'
+                         | 'Preserve'
+                         | 'Private'
+                         | 'Public'
+                         | 'Redim'
+                         | 'Resume'
+                         | 'Select'
+                         | 'Set'
+                         | 'Sub'
+                         | 'Then'
+                         | 'To'
+                         | 'True'
+                         | 'Until'
+                         | 'WEnd'
+                         | 'While'
+                         | 'With'
+                         | 'Xor'
+
+<SafeKeywordID>        ::= 'Default'
+                         | 'Erase'
+                         | 'Error'
+                         | 'Explicit'
+                         | 'Property'
+                         | 'Step'
+
+<ExtendedID>           ::= <SafeKeywordID>
+                         | ID
+
+<IndexOrParamsList>    ::= <IndexOrParams> <IndexOrParamsList>
+                         | <IndexOrParams>
+
+<IndexOrParams>        ::= '(' <Expr> <CommaExprList> ')'
+                         | '(' <CommaExprList> ')'
+                         | '(' <Expr> ')'
+                         | '(' ')'
+
+<IndexOrParamsListDot> ::= <IndexOrParams> <IndexOrParamsListDot>
+                         | <IndexOrParamsDot>
+
+<IndexOrParamsDot>     ::= '(' <Expr> <CommaExprList> ').'
+                         | '(' <CommaExprList> ').'
+                         | '(' <Expr> ').'
+                         | '(' ').'
+
+<CommaExprList>        ::= ',' <Expr> <CommaExprList>
+                         | ',' <CommaExprList>
+                         | ',' <Expr>
+                         | ','
+
+!========= Redim Statement
+
+<RedimStmt>            ::= 'Redim' <RedimDeclList> <NL>
+                         | 'Redim' 'Preserve' <RedimDeclList> <NL>
+
+<RedimDeclList>        ::= <RedimDecl> ',' <RedimDeclList>
+                         | <RedimDecl>
+
+<RedimDecl>            ::= <ExtendedID> '(' <ExprList> ')'
+
+!========= If Statement
+
+<IfStmt>               ::= 'If' <Expr> 'Then' <NL> <BlockStmtList> <ElseStmtList> 'End' 'If' <NL>
+                         | 'If' <Expr> 'Then' <InlineStmt> <ElseOpt> <EndIfOpt> <NL>
+
+<ElseStmtList>         ::= 'ElseIf' <Expr> 'Then' <NL> <BlockStmtList> <ElseStmtList>
+                         | 'ElseIf' <Expr> 'Then' <InlineStmt> <NL> <ElseStmtList>
+                         | 'Else' <InlineStmt> <NL>
+                         | 'Else' <NL> <BlockStmtList>
+                         |
+
+<ElseOpt>              ::= 'Else' <InlineStmt>
+                         |
+
+<EndIfOpt>             ::= 'End' 'If'
+                         |
+
+!========= With Statement
+
+<WithStmt>             ::= 'With' <Expr> <NL> <BlockStmtList> 'End' 'With' <NL>
+
+!========= Loop Statement
+
+<LoopStmt>             ::= 'Do' <LoopType> <Expr> <NL> <BlockStmtList> 'Loop' <NL>
+                         | 'Do' <NL> <BlockStmtList> 'Loop' <LoopType> <Expr> <NL>
+                         | 'Do' <NL> <BlockStmtList> 'Loop' <NL>
+                         | 'While' <Expr> <NL> <BlockStmtList> 'WEnd' <NL>
+
+<LoopType>             ::= 'While'
+                         | 'Until'
+
+!========= For Statement
+
+<ForStmt>              ::= 'For' <ExtendedID> '=' <Expr> 'To' <Expr> <StepOpt> <NL> <BlockStmtList> 'Next' <NL>
+                         | 'For' 'Each' <ExtendedID> 'In' <Expr> <NL> <BlockStmtList> 'Next' <NL>
+
+<StepOpt>              ::= 'Step' <Expr>
+                         |
+
+!========= Select Statement
+
+<SelectStmt>           ::= 'Select' 'Case' <Expr> <NL> <CaseStmtList> 'End' 'Select' <NL>
+
+<CaseStmtList>         ::= 'Case' <ExprList> <NLOpt> <BlockStmtList> <CaseStmtList>
+                         | 'Case' 'Else' <NLOpt> <BlockStmtList>
+                         |
+
+<NLOpt>                ::= <NL>
+                         |
+
+<ExprList>             ::= <Expr> ',' <ExprList>
+                         | <Expr>
+
+!===============================
+! Rules : Expressions
+!===============================
+
+<SubSafeExpr>          ::= <SubSafeImpExpr>
+
+<SubSafeImpExpr>       ::= <SubSafeImpExpr> 'Imp' <EqvExpr>
+                         | <SubSafeEqvExpr>
+
+<SubSafeEqvExpr>       ::= <SubSafeEqvExpr> 'Eqv' <XorExpr>
+                         | <SubSafeXorExpr>
+
+<SubSafeXorExpr>       ::= <SubSafeXorExpr> 'Xor' <OrExpr>
+                         | <SubSafeOrExpr>
+
+<SubSafeOrExpr>        ::= <SubSafeOrExpr> 'Or' <AndExpr>
+                         | <SubSafeAndExpr>
+
+<SubSafeAndExpr>       ::= <SubSafeAndExpr> 'And' <NotExpr>
+                         | <SubSafeNotExpr>
+
+<SubSafeNotExpr>       ::= 'Not' <NotExpr>
+                         | <SubSafeCompareExpr>
+
+<SubSafeCompareExpr>   ::= <SubSafeCompareExpr> 'Is' <ConcatExpr>
+                         | <SubSafeCompareExpr> 'Is' 'Not' <ConcatExpr>
+                         | <SubSafeCompareExpr> '>=' <ConcatExpr>
+                         | <SubSafeCompareExpr> '=>' <ConcatExpr>
+                         | <SubSafeCompareExpr> '<=' <ConcatExpr>
+                         | <SubSafeCompareExpr> '=<' <ConcatExpr>
+                         | <SubSafeCompareExpr> '>'  <ConcatExpr>
+                         | <SubSafeCompareExpr> '<'  <ConcatExpr>
+                         | <SubSafeCompareExpr> '<>' <ConcatExpr>
+                         | <SubSafeCompareExpr> '='  <ConcatExpr>
+                         | <SubSafeConcatExpr>
+
+<SubSafeConcatExpr>    ::= <SubSafeConcatExpr> '&' <AddExpr>
+                         | <SubSafeAddExpr>
+
+<SubSafeAddExpr>       ::= <SubSafeAddExpr> '+' <ModExpr>
+                         | <SubSafeAddExpr> '-' <ModExpr>
+                         | <SubSafeModExpr>
+
+<SubSafeModExpr>       ::= <SubSafeModExpr> 'Mod' <IntDivExpr>
+                         | <SubSafeIntDivExpr>
+
+<SubSafeIntDivExpr>    ::= <SubSafeIntDivExpr> '\' <MultExpr>
+                         | <SubSafeMultExpr>
+
+<SubSafeMultExpr>      ::= <SubSafeMultExpr> '*' <UnaryExpr>
+                         | <SubSafeMultExpr> '/' <UnaryExpr>
+                         | <SubSafeUnaryExpr>
+
+<SubSafeUnaryExpr>     ::= '-' <UnaryExpr>
+                         | '+' <UnaryExpr>
+                         | <SubSafeExpExpr>
+
+<SubSafeExpExpr>       ::= <SubSafeValue> '^' <ExpExpr>
+                         | <SubSafeValue>
+
+<SubSafeValue>         ::= <ConstExpr>
+                         | <LeftExpr>
+!                         | '(' <Expr> ')'
+
+<Expr>                 ::= <ImpExpr>
+
+<ImpExpr>              ::= <ImpExpr> 'Imp' <EqvExpr>
+                         | <EqvExpr>
+
+<EqvExpr>              ::= <EqvExpr> 'Eqv' <XorExpr>
+                         | <XorExpr>
+
+<XorExpr>              ::= <XorExpr> 'Xor' <OrExpr>
+                         | <OrExpr>
+
+<OrExpr>               ::= <OrExpr> 'Or' <AndExpr>
+                         | <AndExpr>
+
+<AndExpr>              ::= <AndExpr> 'And' <NotExpr>
+                         | <NotExpr>
+
+<NotExpr>              ::= 'Not' <NotExpr>
+                         | <CompareExpr>
+
+<CompareExpr>          ::= <CompareExpr> 'Is' <ConcatExpr>
+                         | <CompareExpr> 'Is' 'Not' <ConcatExpr>
+                         | <CompareExpr> '>=' <ConcatExpr>
+                         | <CompareExpr> '=>' <ConcatExpr>
+                         | <CompareExpr> '<=' <ConcatExpr>
+                         | <CompareExpr> '=<' <ConcatExpr>
+                         | <CompareExpr> '>'  <ConcatExpr>
+                         | <CompareExpr> '<'  <ConcatExpr>
+                         | <CompareExpr> '<>' <ConcatExpr>
+                         | <CompareExpr> '='  <ConcatExpr>
+                         | <ConcatExpr>
+
+<ConcatExpr>           ::= <ConcatExpr> '&' <AddExpr>
+                         | <AddExpr>
+
+<AddExpr>              ::= <AddExpr> '+' <ModExpr>
+                         | <AddExpr> '-' <ModExpr>
+                         | <ModExpr>
+
+<ModExpr>              ::= <ModExpr> 'Mod' <IntDivExpr>
+                         | <IntDivExpr>
+
+<IntDivExpr>           ::= <IntDivExpr> '\' <MultExpr>
+                         | <MultExpr>
+
+<MultExpr>             ::= <MultExpr> '*' <UnaryExpr>
+                         | <MultExpr> '/' <UnaryExpr>
+                         | <UnaryExpr>
+
+<UnaryExpr>            ::= '-' <UnaryExpr>
+                         | '+' <UnaryExpr>
+                         | <ExpExpr>
+
+<ExpExpr>              ::= <Value> '^' <ExpExpr>
+                         | <Value>
+
+<Value>                ::= <ConstExpr>
+                         | <LeftExpr>
+                         | '(' <Expr> ')'
+
+<ConstExpr>            ::= <BoolLiteral>
+                         | <IntLiteral>
+                         | FloatLiteral
+                         | StringLiteral
+                         | DateLiteral
+                         | <Nothing>
+
+<BoolLiteral>          ::= 'True'
+                         | 'False'
+
+<IntLiteral>           ::= IntLiteral
+                         | HexLiteral
+                         | OctLiteral
+
+<Nothing>              ::= 'Nothing'
+                         | 'Null'
+                         | 'Empty'

--- a/lib/scripting/vbscript.ne
+++ b/lib/scripting/vbscript.ne
@@ -1,3 +1,4 @@
+@preprocessor typescript
 @builtin "whitespace.ne"
 @builtin "number.ne"
 
@@ -6,7 +7,7 @@ const estree = require('./estree');
 %}
 
 #===============================
-# Rules 
+# Rules
 #===============================
 
 Program              -> NLOpt GlobalStmt:*                            {% data => estree.program(data[1]) %}
@@ -62,10 +63,10 @@ OtherSubCallStmtOpt  -> "," _ Expr                                    {% data =>
 
 SubSafeExprOpt       -> SubSafeExpr                                   {% id %}
 
-QualifiedID          -> IDDot QualifiedIDTail                                      
+QualifiedID          -> IDDot QualifiedIDTail
                       | ID                                            {% id %}
-                       
-QualifiedIDTail      -> IDDot QualifiedIDTail                        
+
+QualifiedIDTail      -> IDDot QualifiedIDTail
                       | ID                                            {% id %}
 
 SafeKeywordID        -> "Default"
@@ -90,7 +91,7 @@ SubSafeValue         -> ConstExpr                                     {% id %}
                       | LeftExpr                                      {% id %}
                       | "(" _ Expr _ ")"
 
-Expr                 -> UnaryExpr                                     {% id %} 
+Expr                 -> UnaryExpr                                     {% id %}
 
 UnaryExpr            -> "-" UnaryExpr                                 {% estree.unaryExpression %}
                       | "+" UnaryExpr                                 {% estree.unaryExpression %}

--- a/lib/scripting/vbscript.ne
+++ b/lib/scripting/vbscript.ne
@@ -1,0 +1,68 @@
+@builtin "whitespace.ne"
+
+@{%
+const estree = require('./estree');
+%}
+
+Program              -> NLOpt GlobalStmt:*                           {% data => estree.program(data[1]) %}
+
+GlobalStmt           -> OptionExplicit
+                      | BlockStmt                                    {% data => data[0] %}
+
+
+OptionExplicit       -> "Option" __ "Explicit" NL
+
+BlockStmt            -> VarDecl                                      {% data => data[0] %}
+
+VarDecl              -> "Dim" __ VarName OtherVarsOpt:* NL           {% estree.varDecl %}
+
+VarName              -> ExtendedID ("(" ArrayRankList ")"):?         {% data => data[0] %}
+
+OtherVarsOpt         -> "," __ VarName                               {% data => data[2] %}
+
+ExtendedID           -> SafeKeywordID
+                      | ID                                           {% data => data[0] %}
+
+SafeKeywordID        -> "Default"
+                      | "Erase"
+                      | "Error"
+                      | "Explicit"
+                      | "Property"
+                      | "Step"
+
+ID                   -> Letter IDTail                                {% data => data[0] + data[1] %}
+                      | "[" IDNameChar:* "]"
+
+ArrayRankList        -> IntLiteral "," ArrayRankList
+                      | IntLiteral
+
+NLOpt                -> NL:*
+
+NL                   -> NewLine NL
+                      | NewLine
+
+NewLine              -> CR LF
+                      | CR
+                      | LF
+                      | ":"
+
+IntLiteral           -> DecDigit:+
+                      | HexLiteral
+                      | OctLiteral
+
+HexLiteral           -> "&H" HexDigit:+ "&":?
+OctLiteral           -> "&" OctDigit:+ "&":?
+
+DecDigit             -> [0-9]
+HexDigit             -> [0-9A-Fa-f]
+OctDigit             -> [0-7]
+
+IDNameChar           -> [\x20-\x5A\x5C\x5E-\x7E\xA0]
+
+Letter               -> [a-zA-Z]
+
+LF                   -> [\n]
+
+CR                   -> [\r]
+
+IDTail               -> [a-zA-Z0-9_]:*                               {% data => data[0].join('') %}

--- a/lib/tslint.json
+++ b/lib/tslint.json
@@ -1,7 +1,7 @@
 {
 	"extends": "tslint:recommended",
 	"linterOptions": {
-		"exclude": ["**/*.js"]
+		"exclude": [ "**/*.js", "**/vbscript.ts" ]
 	},
 	"rules": {
 		"quotemark": [ true, "single", "avoid-escape" ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -195,10 +195,26 @@
 			"integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
 			"dev": true
 		},
+		"@types/astring": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@types/astring/-/astring-1.3.0.tgz",
+			"integrity": "sha512-PYUIKAlUl95QIoWrvTW1aj5YJoiBLukCixTBKkVMq17BbkcX4I6Yn7lkltzsM3fXByV4l2x4tJGYhHqyYnhH4A==",
+			"dev": true,
+			"requires": {
+				"@types/estree": "*",
+				"@types/node": "*"
+			}
+		},
 		"@types/chai": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.0.tgz",
 			"integrity": "sha512-zw8UvoBEImn392tLjxoavuonblX/4Yb9ha4KBU10FirCfwgzhKO0dvyJSF9ByxV1xK1r2AgnAi/tvQaLgxQqxA==",
+			"dev": true
+		},
+		"@types/estree": {
+			"version": "0.0.39",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
 			"dev": true
 		},
 		"@types/gm": {
@@ -220,6 +236,12 @@
 			"version": "5.2.7",
 			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
 			"integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
+			"dev": true
+		},
+		"@types/nearley": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/@types/nearley/-/nearley-2.11.0.tgz",
+			"integrity": "sha512-sW7qB59pz+AJCpiT3ivsMMsr/5stuCUf4IC22QfhYAMItBy3XSjyzCa/oRG+oTTzYnx5VuPtPNHN4fZ0QRnKDg==",
 			"dev": true
 		},
 		"@types/node": {
@@ -370,6 +392,11 @@
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
 			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
 			"dev": true
+		},
+		"astring": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/astring/-/astring-1.4.1.tgz",
+			"integrity": "sha512-CXBXWo/KY1AMtcvXm+92K8y8SQqjs35LJJ2/w5Jlm3srsNyzbRoZmgR05T2Z8CYKH/NpojEtuZThpkwSlMEHKg=="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -1233,6 +1260,11 @@
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
 			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
 			"dev": true
+		},
+		"discontinuous-range": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+			"integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo="
 		},
 		"download": {
 			"version": "6.2.5",
@@ -2635,6 +2667,11 @@
 				}
 			}
 		},
+		"moo": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
+			"integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw=="
+		},
 		"ms": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -2649,6 +2686,25 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.1.tgz",
 			"integrity": "sha512-boQj1WFgQH3v4clhu3mTNfP+vOBxorDlE8EKiMjUlLG3C4qAESnn9AxIOkFgTR2c9LtzNjPrjS60cT27ZKBhaA=="
+		},
+		"nearley": {
+			"version": "2.18.0",
+			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.18.0.tgz",
+			"integrity": "sha512-/zQOMCeJcioI0xJtd5RpBiWw2WP7wLe6vq8/3Yu0rEwgus/G/+pViX80oA87JdVgjRt2895mZSv2VfZmy4W1uw==",
+			"requires": {
+				"commander": "^2.19.0",
+				"moo": "^0.4.3",
+				"railroad-diagrams": "^1.0.0",
+				"randexp": "0.4.6",
+				"semver": "^5.4.1"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.20.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+					"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+				}
+			}
 		},
 		"neo-async": {
 			"version": "2.6.0",
@@ -3290,6 +3346,20 @@
 				"strict-uri-encode": "^1.0.0"
 			}
 		},
+		"railroad-diagrams": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+			"integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234="
+		},
+		"randexp": {
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+			"requires": {
+				"discontinuous-range": "1.0.0",
+				"ret": "~0.1.10"
+			}
+		},
 		"rc": {
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -3422,6 +3492,11 @@
 			"requires": {
 				"lowercase-keys": "^1.0.0"
 			}
+		},
+		"ret": {
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
 		},
 		"rimraf": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 	"scripts": {
 		"build": "rimraf dist && tsc && cp -r res/maps dist/res",
 		"build:watch": "tsc --watch",
-		"compile": "nearleyc lib/scripting/vbscript.ne -o lib/scripting/vbscript.js && tsc lib/scripting/estree",
+		"compile": "nearleyc lib/scripting/vbscript.ne -o lib/scripting/vbscript.ts",
 		"lint": "tslint lib/**/*.ts --format stylish",
 		"test": "nyc mocha"
 	},

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 	"scripts": {
 		"build": "rimraf dist && tsc && cp -r res/maps dist/res",
 		"build:watch": "tsc --watch",
+		"compile": "nearleyc lib/scripting/vbscript.ne -o lib/scripting/vbscript.js && tsc lib/scripting/estree",
 		"lint": "tslint lib/**/*.ts --format stylish",
 		"test": "nyc mocha"
 	},
@@ -35,19 +36,24 @@
 	"author": "freezy <freezy@vpdb.io>",
 	"license": "GPL-2.0",
 	"dependencies": {
+		"astring": "^1.4.1",
 		"buffer": "5.4.0",
 		"es6-promise-pool": "^2.5.0",
 		"gltf-pipeline": "github:freezy/gltf-pipeline#hotfix/dedupe",
 		"gm": "^1.23.1",
+		"nearley": "^2.18.0",
 		"pngquant": "^3.0.0",
 		"sharp": "^0.23.0",
 		"three": "^0.107.0"
 	},
 	"devDependencies": {
+		"@types/astring": "^1.3.0",
 		"@types/chai": "4.2.0",
+		"@types/estree": "0.0.39",
 		"@types/gm": "1.18.4",
 		"@types/microtime": "2.1.0",
 		"@types/mocha": "5.2.7",
+		"@types/nearley": "2.11.0",
 		"@types/node": "12.7.2",
 		"@types/sharp": "0.22.2",
 		"@types/sinon": "7.0.13",


### PR DESCRIPTION
This PR adds initial support for transpiling VBScript into Javascript. 

Currently the grammar can handle:

1. Variable declarations
2. Const declarations
3. Subcall statements with params
4. Subcall statements without params