### PR TITLE
Performance: Recycle objects

### DIFF
--- a/lib/base.ts
+++ b/lib/base.ts
@@ -1,6 +1,0 @@
-
-export abstract class Base {
-	protected constructor() {
-		// sys
-	}
-}

--- a/lib/base.ts
+++ b/lib/base.ts
@@ -1,0 +1,6 @@
+
+export abstract class Base {
+	protected constructor() {
+		// sys
+	}
+}

--- a/lib/game/event-proxy.ts
+++ b/lib/game/event-proxy.ts
@@ -18,7 +18,6 @@
  */
 
 import { HitObject } from '../physics/hit-object';
-import { logger } from '../util/logger';
 import { Ball } from '../vpt/ball/ball';
 import { ItemApi } from '../vpt/item-api';
 import { Event } from './event';

--- a/lib/game/player-physics.ts
+++ b/lib/game/player-physics.ts
@@ -177,6 +177,7 @@ export class PlayerPhysics {
 			}
 
 			this.recordContacts = true;
+			//CollisionEvent.release(...this.contacts);
 			this.contacts = [];
 
 			for (const ball of this.balls) {
@@ -189,26 +190,26 @@ export class PlayerPhysics {
 
 					// always check for playfield and top glass
 					if (!this.meshAsPlayfield) {
-						ball.setCollision(this.hitPlayfield.doHitTest(ball, ball.getCollision(), this));
+						this.hitPlayfield.doHitTest(ball, ball.coll, this);
 					}
-					ball.setCollision(this.hitTopGlass.doHitTest(ball, ball.getCollision(), this));
+					this.hitTopGlass.doHitTest(ball, ball.coll, this);
 
 					// swap order of dynamic and static obj checks randomly
 					if (Math.random() < 0.5) {
-						ball.setCollision(this.hitOcTreeDynamic.hitTestBall(ball, ball.getCollision(), this));  // dynamic objects
-						ball.setCollision(this.hitOcTree.hitTestBall(ball, ball.getCollision(), this));         // find the hit objects and hit times
+						this.hitOcTreeDynamic.hitTestBall(ball, ball.coll, this);  // dynamic objects
+						this.hitOcTree.hitTestBall(ball, ball.coll, this);         // find the hit objects and hit times
 					} else {
-						ball.setCollision(this.hitOcTree.hitTestBall(ball, ball.getCollision(), this));         // find the hit objects and hit times
-						ball.setCollision(this.hitOcTreeDynamic.hitTestBall(ball, ball.getCollision(), this));  // dynamic objects
+						this.hitOcTree.hitTestBall(ball, ball.coll, this);         // find the hit objects and hit times
+						this.hitOcTreeDynamic.hitTestBall(ball, ball.coll, this);  // dynamic objects
 					}
 
-					const htz = ball.getCollision().hitTime;                                 // this ball's hit time
+					const htz = ball.coll.hitTime;                                 // this ball's hit time
 
 					if (htz < 0) {                         // no negative time allowed
-						ball.getCollision().clear();
+						ball.coll.clear();
 					}
 
-					if (ball.getCollision().obj) {
+					if (ball.coll.obj) {
 						///////////////////////////////////////////////////////////////////////////
 						if (htz <= hitTime) {
 							hitTime = htz;                 // record actual event time
@@ -242,15 +243,15 @@ export class PlayerPhysics {
 			for (let i = 0; i < this.balls.length; i++) {
 
 				const ball = this.balls[i];
-				const pho = ball.getCollision().obj; // object that ball hit in trials
+				const pho = ball.coll.obj; // object that ball hit in trials
 
 				// find balls with hit objects and minimum time
-				if (pho && ball.getCollision().hitTime <= hitTime) {
+				if (pho && ball.coll.hitTime <= hitTime) {
 					// now collision, contact and script reactions on active ball (object)+++++++++
 
 					this.activeBall = ball;                         // For script that wants the ball doing the collision
-					pho.collide(ball.getCollision(), this);          // !!!!! 3) collision on active ball
-					ball.getCollision().clear();                     // remove trial hit object pointer
+					pho.collide(ball.coll, this);          // !!!!! 3) collision on active ball
+					ball.coll.clear();                     // remove trial hit object pointer
 
 					// Collide may have changed the velocity of the ball,
 					// and therefore the bounding box for the next hit cycle
@@ -285,6 +286,7 @@ export class PlayerPhysics {
 					this.contacts[i].obj!.contact(this.contacts[i], hitTime, this);
 				}
 			}
+			//CollisionEvent.release(...this.contacts);
 			this.contacts = [];
 
 			// fixme ballspinhack

--- a/lib/game/player-physics.ts
+++ b/lib/game/player-physics.ts
@@ -376,7 +376,7 @@ export class PlayerPhysics {
 	public createBall(ballCreator: IBallCreationPosition, radius = 25, mass = 1): Ball {
 
 		const data = new BallData(radius, mass, this.table.data!.defaultBulbIntensityScaleOnBall);
-		const state = new BallState(`Ball${Ball.idCounter}`, ballCreator.getBallCreationPosition(this.table), new Matrix2D());
+		const state = BallState.claim(`Ball${Ball.idCounter}`, ballCreator.getBallCreationPosition(this.table));
 		state.pos.z += data.radius;
 
 		const ball = new Ball(data, state, ballCreator.getBallCreationVelocity(this.table), this.table.data!);

--- a/lib/game/player-physics.ts
+++ b/lib/game/player-physics.ts
@@ -177,7 +177,7 @@ export class PlayerPhysics {
 			}
 
 			this.recordContacts = true;
-			//CollisionEvent.release(...this.contacts);
+			CollisionEvent.release(...this.contacts);
 			this.contacts = [];
 
 			for (const ball of this.balls) {
@@ -286,7 +286,7 @@ export class PlayerPhysics {
 					this.contacts[i].obj!.contact(this.contacts[i], hitTime, this);
 				}
 			}
-			//CollisionEvent.release(...this.contacts);
+			CollisionEvent.release(...this.contacts);
 			this.contacts = [];
 
 			// fixme ballspinhack

--- a/lib/game/player-physics.ts
+++ b/lib/game/player-physics.ts
@@ -19,7 +19,6 @@
 
 import { Table } from '..';
 import { degToRad } from '../math/float';
-import { Matrix2D } from '../math/matrix2d';
 import { Vertex3D } from '../math/vertex3d';
 import { CollisionEvent } from '../physics/collision-event';
 import {

--- a/lib/game/player-physics.ts
+++ b/lib/game/player-physics.ts
@@ -178,7 +178,7 @@ export class PlayerPhysics {
 
 			this.recordContacts = true;
 			CollisionEvent.release(...this.contacts);
-			this.contacts = [];
+			this.contacts.length = 0;
 
 			for (const ball of this.balls) {
 				const ballHit = ball.hit;
@@ -287,7 +287,7 @@ export class PlayerPhysics {
 				}
 			}
 			CollisionEvent.release(...this.contacts);
-			this.contacts = [];
+			this.contacts.length = 0;
 
 			// fixme ballspinhack
 

--- a/lib/game/player.ts
+++ b/lib/game/player.ts
@@ -170,8 +170,8 @@ export class ChangedStates<STATE extends ItemState = ItemState> {
 	public release(): void {
 		for (const name of this.keys) {
 			this.changedStates[name].release();
+			delete this.changedStates[name];
 		}
-		this.changedStates = {};
 		ChangedStates.POOL.release(this);
 	}
 }

--- a/lib/math/functions.ts
+++ b/lib/math/functions.ts
@@ -17,6 +17,15 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+const solution: [number, number] = [0, 0];
+
+/**
+ * Solves an quadratic equation.
+ *
+ * Note that the result is recycled, meaning running it twice will make the second
+ * run update the first run's result, so retrieve the result before running it a
+ * second time in a row!
+ */
 export function solveQuadraticEq(a: number, b: number, c: number): [number, number] | undefined {
 	let discr = b * b - 4.0 * a * c;
 
@@ -27,10 +36,10 @@ export function solveQuadraticEq(a: number, b: number, c: number): [number, numb
 	discr = Math.sqrt(discr);
 
 	const invA = (-0.5) / a;
-	const sol1 = (b + discr) * invA;
-	const sol2 = (b - discr) * invA;
+	solution[0] = (b + discr) * invA;
+	solution[1] = (b - discr) * invA;
 
-	return [sol1, sol2];
+	return solution;
 }
 
 export function clamp(x: number, min: number, max: number) {

--- a/lib/math/matrix2d.ts
+++ b/lib/math/matrix2d.ts
@@ -106,6 +106,14 @@ export class Matrix2D {
 		return m;
 	}
 
+	public set(m: Matrix2D) {
+		for (let i = 0; i < 3; ++i) {
+			for (let l = 0; l < 3; ++l) {
+				this.matrix[i][l] = m.matrix[i][l];
+			}
+		}
+	}
+
 	public multiplyMatrix(m1: Matrix2D, m2: Matrix2D) {
 		for (let i = 0; i < 3; ++i) {
 			for (let l = 0; l < 3; ++l) {

--- a/lib/math/matrix2d.ts
+++ b/lib/math/matrix2d.ts
@@ -27,11 +27,16 @@ export class Matrix2D {
 		[ 0, 0, 1 ],
 	];
 
-	public multiplyVectorT(v: Vertex3D): Vertex3D {
-		return new Vertex3D(
-			this.matrix[0][0] * v.x + this.matrix[1][0] * v.y + this.matrix[2][0] * v.z,
-			this.matrix[0][1] * v.x + this.matrix[1][1] * v.y + this.matrix[2][1] * v.z,
-			this.matrix[0][2] * v.x + this.matrix[1][2] * v.y + this.matrix[2][2] * v.z);
+	public multiplyVectorT(v: Vertex3D, recycle = false): Vertex3D {
+		return recycle
+			? Vertex3D.claim(
+				this.matrix[0][0] * v.x + this.matrix[1][0] * v.y + this.matrix[2][0] * v.z,
+				this.matrix[0][1] * v.x + this.matrix[1][1] * v.y + this.matrix[2][1] * v.z,
+				this.matrix[0][2] * v.x + this.matrix[1][2] * v.y + this.matrix[2][2] * v.z)
+			: new Vertex3D(
+				this.matrix[0][0] * v.x + this.matrix[1][0] * v.y + this.matrix[2][0] * v.z,
+				this.matrix[0][1] * v.x + this.matrix[1][1] * v.y + this.matrix[2][1] * v.z,
+				this.matrix[0][2] * v.x + this.matrix[1][2] * v.y + this.matrix[2][2] * v.z);
 	}
 
 	public rotationAroundAxis(axis: Vertex3D, rsin: number, rcos: number) {

--- a/lib/math/matrix2d.ts
+++ b/lib/math/matrix2d.ts
@@ -83,7 +83,7 @@ export class Matrix2D {
 		this.matrix[2][2] = axis.z * axis.z + rcos * (1.0 - axis.z * axis.z);
 	}
 
-	public createSkewSymmetric(pv3D: Vertex3D) {
+	public createSkewSymmetric(pv3D: Vertex3D): this {
 		this.matrix[0][0] = 0;
 		this.matrix[0][1] = -pv3D.z;
 		this.matrix[0][2] = pv3D.y;
@@ -93,6 +93,7 @@ export class Matrix2D {
 		this.matrix[2][0] = -pv3D.y;
 		this.matrix[2][1] = pv3D.x;
 		this.matrix[2][2] = 0;
+		return this;
 	}
 
 	public clone(recycle = false): Matrix2D {

--- a/lib/math/matrix3d.ts
+++ b/lib/math/matrix3d.ts
@@ -144,9 +144,13 @@ export class Matrix3D {
 	public applyToObject3D(obj: Object3D) {
 		if (!obj.matrix) {
 			obj.matrix = new Matrix4();
+		} else {
+			obj.matrix.identity();
 		}
-		this.applyToThreeMatrix4(obj.matrix);
-		obj.matrixWorldNeedsUpdate = true;
+		const m4 = Pool.GENERIC.Matrix4.get();
+		this.applyToThreeMatrix4(m4);
+		obj.applyMatrix(m4);
+		Pool.GENERIC.Matrix4.release(m4);
 	}
 
 	public applyToThreeMatrix4(matrix: Matrix4): Matrix4 {

--- a/lib/math/matrix3d.ts
+++ b/lib/math/matrix3d.ts
@@ -66,6 +66,15 @@ export class Matrix3D {
 		return this;
 	}
 
+	public setEach(...m: number[]): this {
+		for (let i = 0; i < 4; i++) {
+			for (let j = 0; j < 4; j++) {
+				this.matrix[i][j] = m[i * 4 + j];
+			}
+		}
+		return this;
+	}
+
 	public setIdentity(): this {
 		this._11 = this._22 = this._33 = this._44 = 1.0;
 		this._12 = this._13 = this._14 = this._41 =
@@ -249,5 +258,5 @@ export class Matrix3D {
 	get _44() { return this.matrix[3][3]; }
 	set _44(v) { this.matrix[3][3] = f4(v); }
 
-	public static readonly RIGHT_HANDED = new Matrix3D().set([ [1, 0, 0, 0], [0, 1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1] ]);
+	public static readonly RIGHT_HANDED = new Matrix3D().setEach(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1);
 }

--- a/lib/math/matrix3d.ts
+++ b/lib/math/matrix3d.ts
@@ -66,17 +66,6 @@ export class Matrix3D {
 		return this;
 	}
 
-	public equals(matrix: Matrix3D): boolean {
-		for (let i = 0; i < 4; i++) {
-			for (let j = 0; j < 4; j++) {
-				if (this.matrix[i][j] !== matrix.matrix[i][j]) {
-					return false;
-				}
-			}
-		}
-		return true;
-	}
-
 	public setIdentity(): this {
 		this._11 = this._22 = this._33 = this._44 = 1.0;
 		this._12 = this._13 = this._14 = this._41 =
@@ -125,23 +114,8 @@ export class Matrix3D {
 		return this;
 	}
 
-	public multiplyVector(v: Vertex3D): Vertex3D {
-		// Transform it through the current matrix set
-		const xp = f4(f4(f4(f4(this._11 * v.x) + f4(this._21 * v.y)) + f4(this._31 * v.z)) + this._41);
-		const yp = f4(f4(f4(f4(this._12 * v.x) + f4(this._22 * v.y)) + f4(this._32 * v.z)) + this._42);
-		const zp = f4(f4(f4(f4(this._13 * v.x) + f4(this._23 * v.y)) + f4(this._33 * v.z)) + this._43);
-		const wp = f4(f4(f4(f4(this._14 * v.x) + f4(this._24 * v.y)) + f4(this._34 * v.z)) + this._44);
-		const invWp = f4(1.0 / wp);
-		return new Vertex3D(xp * invWp, yp * invWp, zp * invWp);
-	}
-
-	public multiplyVectorNoTranslate(v: Vertex3D): Vertex3D {
-		// Transform it through the current matrix set
-		const xp = f4(f4(this._11 * v.x) + f4(this._21 * v.y)) + f4(this._31 * v.z);
-		const yp = f4(f4(this._12 * v.x) + f4(this._22 * v.y)) + f4(this._32 * v.z);
-		const zp = f4(f4(this._13 * v.x) + f4(this._23 * v.y)) + f4(this._33 * v.z);
-		return new Vertex3D(xp, yp, zp);
-	}
+	/* multiplyVector() has moved to {@link Vertex3D.multiplyMatrix()} */
+	/* multiplyVectorNoTranslate() has moved to {@link Vertex3D.multiplyMatrixNoTranslate()} */
 
 	public multiply(a: Matrix3D, b?: Matrix3D): this {
 		const product = b
@@ -167,7 +141,6 @@ export class Matrix3D {
 		return matrix;
 	}
 
-	/** istanbul ignore next */
 	public toThreeMatrix4(): Matrix4 {
 		const matrix = new Matrix4();
 		matrix.set(
@@ -180,6 +153,7 @@ export class Matrix3D {
 	}
 
 	private static multiplyMatrices(a: Matrix3D, b: Matrix3D, recycle = false): Matrix3D {
+		/* istanbul ignore else: we always recycle now */
 		const result = recycle ? Matrix3D.claim() : new Matrix3D();
 		for (let i = 0; i < 4; ++i) {
 			for (let l = 0; l < 4; ++l) {
@@ -197,7 +171,19 @@ export class Matrix3D {
 		return recycle ? Matrix3D.claim().set(this.matrix) : new Matrix3D().set(this.matrix);
 	}
 
-	/** istanbul ignore next */
+	/* istanbul ignore next: for debugging */
+	public equals(matrix: Matrix3D): boolean {
+		for (let i = 0; i < 4; i++) {
+			for (let j = 0; j < 4; j++) {
+				if (this.matrix[i][j] !== matrix.matrix[i][j]) {
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
+	/* istanbul ignore next */
 	public debug(): string[] {
 		return [
 			`_11: ${fr(this._11)}`,

--- a/lib/math/matrix3d.ts
+++ b/lib/math/matrix3d.ts
@@ -20,7 +20,6 @@
 import { Matrix4, Object3D } from 'three';
 import { Pool } from '../util/object-pool';
 import { f4, fr } from './float';
-import { Vertex3D } from './vertex3d';
 
 /**
  * Three's Matrix4.multiply() gives different results than VPinball's. Duh.

--- a/lib/math/matrix3d.ts
+++ b/lib/math/matrix3d.ts
@@ -17,7 +17,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { Matrix4 } from 'three';
+import { Matrix4, Object3D } from 'three';
 import { Pool } from '../util/object-pool';
 import { f4, fr } from './float';
 import { Vertex3D } from './vertex3d';
@@ -134,15 +134,34 @@ export class Matrix3D {
 		return this;
 	}
 
-	public toRightHanded(recycle = false): Matrix3D {
+	public toRightHanded(): this {
 		const tempMat = Matrix3D.claim().setScaling(1, 1, -1);
-		const matrix = this.clone(recycle).multiply(tempMat);
+		this.multiply(tempMat);
 		Matrix3D.release(tempMat);
+		return this;
+	}
+
+	public applyToObject3D(obj: Object3D) {
+		if (!obj.matrix) {
+			obj.matrix = new Matrix4();
+		}
+		this.applyToThreeMatrix4(obj.matrix);
+		obj.matrixWorldNeedsUpdate = true;
+	}
+
+	/** @deprecated Use applyToThreeMatrix4 */
+	public toThreeMatrix4(): Matrix4 {
+		const matrix = new Matrix4();
+		matrix.set(
+			this._11, this._21, this._31, this._41,
+			this._12, this._22, this._32, this._42,
+			this._13, this._23, this._33, this._43,
+			this._14, this._24, this._34, this._44,
+		);
 		return matrix;
 	}
 
-	public toThreeMatrix4(): Matrix4 {
-		const matrix = new Matrix4();
+	public applyToThreeMatrix4(matrix: Matrix4): Matrix4 {
 		matrix.set(
 			this._11, this._21, this._31, this._41,
 			this._12, this._22, this._32, this._42,

--- a/lib/math/matrix3d.ts
+++ b/lib/math/matrix3d.ts
@@ -149,18 +149,6 @@ export class Matrix3D {
 		obj.matrixWorldNeedsUpdate = true;
 	}
 
-	/** @deprecated Use applyToThreeMatrix4 */
-	public toThreeMatrix4(): Matrix4 {
-		const matrix = new Matrix4();
-		matrix.set(
-			this._11, this._21, this._31, this._41,
-			this._12, this._22, this._32, this._42,
-			this._13, this._23, this._33, this._43,
-			this._14, this._24, this._34, this._44,
-		);
-		return matrix;
-	}
-
 	public applyToThreeMatrix4(matrix: Matrix4): Matrix4 {
 		matrix.set(
 			this._11, this._21, this._31, this._41,

--- a/lib/math/vertex2d.ts
+++ b/lib/math/vertex2d.ts
@@ -24,7 +24,7 @@ import { IRenderVertex, Vertex } from './vertex';
 
 export class Vertex2D implements Vertex {
 
-	private static POOL = new Pool(Vertex2D);
+	private static readonly POOL = new Pool(Vertex2D);
 
 	public readonly isVector2 = true;
 	public readonly isVector3 = false;

--- a/lib/math/vertex2d.ts
+++ b/lib/math/vertex2d.ts
@@ -54,6 +54,12 @@ export class Vertex2D implements Vertex {
 		return Vertex2D.POOL.get().set(x || 0, y || 0);
 	}
 
+	public static release(...vertices: Vertex2D[]) {
+		for (const vertex of vertices) {
+			Vertex2D.POOL.release(vertex);
+		}
+	}
+
 	public static reset(v: Vertex2D): void {
 		v.set(0, 0);
 	}
@@ -73,10 +79,6 @@ export class Vertex2D implements Vertex {
 			Vertex2D.POOL.get().set(this._x, this._y);
 		}
 		return new Vertex2D(this._x, this._y);
-	}
-
-	public release() {
-		Vertex2D.POOL.release(this);
 	}
 
 	public add(v: Vertex2D): this {

--- a/lib/math/vertex2d.ts
+++ b/lib/math/vertex2d.ts
@@ -24,7 +24,7 @@ import { IRenderVertex, Vertex } from './vertex';
 
 export class Vertex2D implements Vertex {
 
-	private static readonly POOL = new Pool(Vertex2D);
+	public static readonly POOL = new Pool(Vertex2D);
 
 	public readonly isVector2 = true;
 	public readonly isVector3 = false;
@@ -142,3 +142,5 @@ export class RenderVertex extends Vertex2D implements IRenderVertex {
 		super(x, y);
 	}
 }
+
+//setTimeout(() => Vertex2D.POOL.enableDebug(10000), 20000);

--- a/lib/math/vertex2d.ts
+++ b/lib/math/vertex2d.ts
@@ -50,7 +50,7 @@ export class Vertex2D implements Vertex {
 		return v2;
 	}
 
-	public static claim(x?: number, y?: number, z?: number): Vertex2D {
+	public static claim(x?: number, y?: number): Vertex2D {
 		return Vertex2D.POOL.get().set(x || 0, y || 0);
 	}
 

--- a/lib/math/vertex2d.ts
+++ b/lib/math/vertex2d.ts
@@ -18,10 +18,13 @@
  */
 
 /* tslint:disable:variable-name adjacent-overload-signatures */
+import { Pool } from '../util/object-pool';
 import { f4 } from './float';
 import { IRenderVertex, Vertex } from './vertex';
 
 export class Vertex2D implements Vertex {
+
+	private static POOL = new Pool(Vertex2D);
 
 	public readonly isVector2 = true;
 	public readonly isVector3 = false;
@@ -47,6 +50,14 @@ export class Vertex2D implements Vertex {
 		return v2;
 	}
 
+	public static claim(x?: number, y?: number, z?: number): Vertex2D {
+		return Vertex2D.POOL.get().set(x || 0, y || 0);
+	}
+
+	public static reset(v: Vertex2D): void {
+		v.set(0, 0);
+	}
+
 	public set(x: number, y: number): this {
 		this.x = x;
 		this.y = y;
@@ -57,8 +68,15 @@ export class Vertex2D implements Vertex {
 		return this.set(0, 0);
 	}
 
-	public clone(): Vertex2D {
+	public clone(recycle = false): Vertex2D {
+		if (recycle) {
+			Vertex2D.POOL.get().set(this._x, this._y);
+		}
 		return new Vertex2D(this._x, this._y);
+	}
+
+	public release() {
+		Vertex2D.POOL.release(this);
 	}
 
 	public add(v: Vertex2D): this {

--- a/lib/math/vertex2d.ts
+++ b/lib/math/vertex2d.ts
@@ -87,9 +87,21 @@ export class Vertex2D implements Vertex {
 		return this;
 	}
 
+	public addAndRelease(v: Vertex2D): this {
+		this.add(v);
+		Vertex2D.release(v);
+		return this;
+	}
+
 	public sub(v: Vertex2D): this {
 		this.x -= v.x;
 		this.y -= v.y;
+		return this;
+	}
+
+	public subAndRelease(v: Vertex2D): this {
+		this.sub(v);
+		Vertex2D.release(v);
 		return this;
 	}
 

--- a/lib/math/vertex2d.ts
+++ b/lib/math/vertex2d.ts
@@ -76,7 +76,7 @@ export class Vertex2D implements Vertex {
 
 	public clone(recycle = false): Vertex2D {
 		if (recycle) {
-			Vertex2D.POOL.get().set(this._x, this._y);
+			return Vertex2D.POOL.get().set(this._x, this._y);
 		}
 		return new Vertex2D(this._x, this._y);
 	}

--- a/lib/math/vertex3d.ts
+++ b/lib/math/vertex3d.ts
@@ -94,6 +94,14 @@ export class Vertex3D implements Vertex {
 		return this;
 	}
 
+	public setAndRelease(v: Vertex3D): this {
+		this.x = v.x;
+		this.y = v.y;
+		this.z = v.z;
+		Vertex3D.release(v);
+		return this;
+	}
+
 	public clone(recycle = false): Vertex3D {
 		if (recycle) {
 			Vertex3D.POOL.get().set(this._x, this._y, this._z);

--- a/lib/math/vertex3d.ts
+++ b/lib/math/vertex3d.ts
@@ -296,5 +296,3 @@ export class RenderVertex3D extends Vertex3D implements IRenderVertex {
 		super(x, y, z);
 	}
 }
-
-//setTimeout(() => Vertex3D.POOL.enableDebug(20000), 20000);

--- a/lib/math/vertex3d.ts
+++ b/lib/math/vertex3d.ts
@@ -242,8 +242,7 @@ export class Vertex3D implements Vertex {
 	}
 
 	public static getRotatedAxis(angle: number, axis: Vertex3D, temp: Vertex3D): Vertex3D {
-		const u = axis.clone();
-		u.normalize();
+		const u = axis.clone(true).normalize();
 
 		const sinAngle = f4(Math.sin(f4(f4(Math.PI / 180.0) * angle)));
 		const cosAngle = f4(Math.cos(f4(f4(Math.PI / 180.0) * angle)));
@@ -265,6 +264,7 @@ export class Vertex3D implements Vertex {
 		rotMatrixRow2.y = f4(f4(u.y * u.z) * oneMinusCosAngle) + f4(sinAngle * u.x);
 		rotMatrixRow2.z = f4(u.z * u.z) + f4(cosAngle * f4(1.0 - f4(u.z * u.z)));
 
+		Vertex3D.release(u);
 		return new Vertex3D(temp.dot(rotMatrixRow0), temp.dot(rotMatrixRow1), temp.dot(rotMatrixRow2));
 	}
 

--- a/lib/math/vertex3d.ts
+++ b/lib/math/vertex3d.ts
@@ -22,6 +22,7 @@ import { Pool } from '../util/object-pool';
 import { FLT_MIN } from '../vpt/mesh';
 import { f4 } from './float';
 import { Matrix2D } from './matrix2d';
+import { Matrix3D } from './matrix3d';
 import { IRenderVertex, Vertex } from './vertex';
 import { Vertex2D } from './vertex2d';
 
@@ -265,6 +266,24 @@ export class Vertex3D implements Vertex {
 		rotMatrixRow2.z = f4(u.z * u.z) + f4(cosAngle * f4(1.0 - f4(u.z * u.z)));
 
 		return new Vertex3D(temp.dot(rotMatrixRow0), temp.dot(rotMatrixRow1), temp.dot(rotMatrixRow2));
+	}
+
+	public multiplyMatrix(matrix: Matrix3D) {
+		// Transform it through the current matrix set
+		const xp = f4(f4(f4(f4(matrix._11 * this.x) + f4(matrix._21 * this.y)) + f4(matrix._31 * this.z)) + matrix._41);
+		const yp = f4(f4(f4(f4(matrix._12 * this.x) + f4(matrix._22 * this.y)) + f4(matrix._32 * this.z)) + matrix._42);
+		const zp = f4(f4(f4(f4(matrix._13 * this.x) + f4(matrix._23 * this.y)) + f4(matrix._33 * this.z)) + matrix._43);
+		const wp = f4(f4(f4(f4(matrix._14 * this.x) + f4(matrix._24 * this.y)) + f4(matrix._34 * this.z)) + matrix._44);
+		const invWp = f4(1.0 / wp);
+		return this.set(xp * invWp, yp * invWp, zp * invWp);
+	}
+
+	public multiplyMatrixNoTranslate(matrix: Matrix3D): Vertex3D {
+		// Transform it through the current matrix set
+		const xp = f4(f4(matrix._11 * this.x) + f4(matrix._21 * this.y)) + f4(matrix._31 * this.z);
+		const yp = f4(f4(matrix._12 * this.x) + f4(matrix._22 * this.y)) + f4(matrix._32 * this.z);
+		const zp = f4(f4(matrix._13 * this.x) + f4(matrix._23 * this.y)) + f4(matrix._33 * this.z);
+		return this.set(xp, yp, zp);
 	}
 }
 

--- a/lib/math/vertex3d.ts
+++ b/lib/math/vertex3d.ts
@@ -28,7 +28,7 @@ import { Vertex2D } from './vertex2d';
 
 export class Vertex3D implements Vertex {
 
-	private static readonly POOL = new Pool(Vertex3D);
+	public static readonly POOL = new Pool(Vertex3D);
 
 	public readonly isVector2 = false;
 	public readonly isVector3 = true;
@@ -296,3 +296,5 @@ export class RenderVertex3D extends Vertex3D implements IRenderVertex {
 		super(x, y, z);
 	}
 }
+
+//setTimeout(() => Vertex3D.POOL.enableDebug(10000), 10000);

--- a/lib/math/vertex3d.ts
+++ b/lib/math/vertex3d.ts
@@ -104,7 +104,7 @@ export class Vertex3D implements Vertex {
 
 	public clone(recycle = false): Vertex3D {
 		if (recycle) {
-			Vertex3D.POOL.get().set(this._x, this._y, this._z);
+			return Vertex3D.POOL.get().set(this._x, this._y, this._z);
 		}
 		return new Vertex3D(this._x, this._y, this._z);
 	}

--- a/lib/math/vertex3d.ts
+++ b/lib/math/vertex3d.ts
@@ -25,8 +25,9 @@ import { Matrix2D } from './matrix2d';
 import { Matrix3D } from './matrix3d';
 import { IRenderVertex, Vertex } from './vertex';
 import { Vertex2D } from './vertex2d';
+import { Base } from '../base';
 
-export class Vertex3D implements Vertex {
+export class Vertex3D extends Base implements Vertex {
 
 	public static readonly POOL = new Pool(Vertex3D);
 
@@ -74,6 +75,7 @@ export class Vertex3D implements Vertex {
 	}
 
 	constructor(x?: number, y?: number, z?: number) {
+		super();
 		this.x = x || 0;
 		this.y = y || 0;
 		this.z = z || 0;

--- a/lib/math/vertex3d.ts
+++ b/lib/math/vertex3d.ts
@@ -297,4 +297,4 @@ export class RenderVertex3D extends Vertex3D implements IRenderVertex {
 	}
 }
 
-//setTimeout(() => Vertex3D.POOL.enableDebug(10000), 10000);
+//setTimeout(() => Vertex3D.POOL.enableDebug(20000), 20000);

--- a/lib/math/vertex3d.ts
+++ b/lib/math/vertex3d.ts
@@ -144,6 +144,12 @@ export class Vertex3D implements Vertex {
 		return f4(f4(this.x * v.x) + f4(this.y * v.y)) + f4(this.z * v.z);
 	}
 
+	public dotAndRelease(v: Vertex3D): number {
+		const dot = this.dot(v);
+		Vertex3D.release(v);
+		return dot;
+	}
+
 	public sub(v: Vertex3D): this {
 		this.x -= v.x;
 		this.y -= v.y;
@@ -151,10 +157,22 @@ export class Vertex3D implements Vertex {
 		return this;
 	}
 
+	public subAndRelease(v: Vertex3D): this {
+		this.sub(v);
+		Vertex3D.release(v);
+		return this;
+	}
+
 	public add(v: Vertex3D): this {
 		this.x += v.x;
 		this.y += v.y;
 		this.z += v.z;
+		return this;
+	}
+
+	public addAndRelease(v: Vertex3D): this {
+		this.add(v);
+		Vertex3D.release(v);
 		return this;
 	}
 
@@ -194,12 +212,18 @@ export class Vertex3D implements Vertex {
 		return v.x === this.x && v.y === this.y && v.z === this.z;
 	}
 
-	public static crossProduct(pv1: Vertex3D, pv2: Vertex3D): Vertex3D {
-		return new Vertex3D(
-			pv1.y * pv2.z - pv1.z * pv2.y,
-			pv1.z * pv2.x - pv1.x * pv2.z,
-			pv1.x * pv2.y - pv1.y * pv2.x,
-		);
+	public static crossProduct(pv1: Vertex3D, pv2: Vertex3D, recycle = false): Vertex3D {
+		return recycle
+			? Vertex3D.claim(
+				pv1.y * pv2.z - pv1.z * pv2.y,
+				pv1.z * pv2.x - pv1.x * pv2.z,
+				pv1.x * pv2.y - pv1.y * pv2.x,
+			)
+			: new Vertex3D(
+				pv1.y * pv2.z - pv1.z * pv2.y,
+				pv1.z * pv2.x - pv1.x * pv2.z,
+				pv1.x * pv2.y - pv1.y * pv2.x,
+			);
 	}
 
 	public static crossZ(rz: number, v: Vertex3D) {

--- a/lib/math/vertex3d.ts
+++ b/lib/math/vertex3d.ts
@@ -62,6 +62,12 @@ export class Vertex3D implements Vertex {
 		return Vertex3D.POOL.get().set(x || 0, y || 0, z || 0);
 	}
 
+	public static release(...vertices: Vertex3D[]) {
+		for (const vertex of vertices) {
+			Vertex3D.POOL.release(vertex);
+		}
+	}
+
 	public static reset(v: Vertex3D): void {
 		v.set(0, 0, 0);
 	}
@@ -93,10 +99,6 @@ export class Vertex3D implements Vertex {
 			Vertex3D.POOL.get().set(this._x, this._y, this._z);
 		}
 		return new Vertex3D(this._x, this._y, this._z);
-	}
-
-	public release() {
-		Vertex3D.POOL.release(this);
 	}
 
 	public normalize(): this {

--- a/lib/math/vertex3d.ts
+++ b/lib/math/vertex3d.ts
@@ -25,9 +25,8 @@ import { Matrix2D } from './matrix2d';
 import { Matrix3D } from './matrix3d';
 import { IRenderVertex, Vertex } from './vertex';
 import { Vertex2D } from './vertex2d';
-import { Base } from '../base';
 
-export class Vertex3D extends Base implements Vertex {
+export class Vertex3D implements Vertex {
 
 	public static readonly POOL = new Pool(Vertex3D);
 
@@ -75,7 +74,6 @@ export class Vertex3D extends Base implements Vertex {
 	}
 
 	constructor(x?: number, y?: number, z?: number) {
-		super();
 		this.x = x || 0;
 		this.y = y || 0;
 		this.z = z || 0;

--- a/lib/math/vertex3d.ts
+++ b/lib/math/vertex3d.ts
@@ -226,8 +226,10 @@ export class Vertex3D implements Vertex {
 			);
 	}
 
-	public static crossZ(rz: number, v: Vertex3D) {
-		return new Vertex3D(-rz * v.y, rz * v.x, 0);
+	public static crossZ(rz: number, v: Vertex3D, recycle = false) {
+		return recycle
+			? Vertex3D.claim(-rz * v.y, rz * v.x, 0)
+			: new Vertex3D(-rz * v.y, rz * v.x, 0);
 	}
 
 	public static getRotatedAxis(angle: number, axis: Vertex3D, temp: Vertex3D): Vertex3D {

--- a/lib/math/vertex3d.ts
+++ b/lib/math/vertex3d.ts
@@ -27,7 +27,7 @@ import { Vertex2D } from './vertex2d';
 
 export class Vertex3D implements Vertex {
 
-	private static POOL = new Pool(Vertex3D);
+	private static readonly POOL = new Pool(Vertex3D);
 
 	public readonly isVector2 = false;
 	public readonly isVector3 = true;

--- a/lib/physics/collision-event.ts
+++ b/lib/physics/collision-event.ts
@@ -19,10 +19,13 @@
 
 import { Vertex2D } from '../math/vertex2d';
 import { Vertex3D } from '../math/vertex3d';
+import { Pool } from '../util/object-pool';
 import { Ball } from '../vpt/ball/ball';
 import { HitObject } from './hit-object';
 
 export class CollisionEvent {
+
+	private static readonly POOL = new Pool(CollisionEvent);
 
 	/**
 	 * The ball that collided with something
@@ -74,8 +77,33 @@ export class CollisionEvent {
 	 */
 	public hitFlag: boolean = false;
 
-	constructor(ball: Ball) {
-		this.ball = ball;
+	constructor(ball?: Ball) {
+		this.ball = ball!;
+	}
+
+	public static claim(ball: Ball): CollisionEvent {
+		const event = CollisionEvent.POOL.get();
+		event.ball = ball;
+		return event;
+	}
+
+	public static release(...events: CollisionEvent[]) {
+		for (const event of events) {
+			CollisionEvent.POOL.release(event);
+		}
+	}
+
+	public static reset(event: CollisionEvent): void {
+		event.ball = undefined!;
+		event.obj = undefined;
+		event.isContact = false;
+		event.hitTime = 0;
+		event.hitDistance = 0;
+		event.hitNormal.setZero();
+		event.hitVel.setZero();
+		event.hitOrgNormalVelocity = 0;
+		event.hitMomentBit = true;
+		event.hitFlag = false;
 	}
 
 	public clear() {

--- a/lib/physics/collision-event.ts
+++ b/lib/physics/collision-event.ts
@@ -52,7 +52,7 @@ export class CollisionEvent {
 	/**
 	 * Additional collision information
 	 */
-	public hitNormal?: Vertex3D;
+	public hitNormal: Vertex3D = new Vertex3D();
 
 	/**
 	 * Only "correctly" used by plunger and flipper

--- a/lib/physics/collision-event.ts
+++ b/lib/physics/collision-event.ts
@@ -82,17 +82,17 @@ export class CollisionEvent {
 		this.obj = undefined;
 	}
 
-	// public set(coll: CollisionEvent): this {
-	// 	this.ball = coll.ball;
-	// 	this.obj = coll.obj;
-	// 	this.isContact = coll.isContact;
-	// 	this.hitTime = coll.hitTime;
-	// 	this.hitDistance = coll.hitDistance;
-	// 	this.hitNormal = coll.hitNormal;
-	// 	this.hitVel = coll.hitVel;
-	// 	this.hitOrgNormalVelocity = coll.hitOrgNormalVelocity;
-	// 	this.hitMomentBit = coll.hitMomentBit;
-	// 	this.hitFlag = coll.hitFlag;
-	// 	return this;
-	// }
+	public set(coll: CollisionEvent): this {
+		this.ball = coll.ball;
+		this.obj = coll.obj;
+		this.isContact = coll.isContact;
+		this.hitTime = coll.hitTime;
+		this.hitDistance = coll.hitDistance;
+		this.hitNormal = coll.hitNormal;
+		this.hitVel = coll.hitVel;
+		this.hitOrgNormalVelocity = coll.hitOrgNormalVelocity;
+		this.hitMomentBit = coll.hitMomentBit;
+		this.hitFlag = coll.hitFlag;
+		return this;
+	}
 }

--- a/lib/physics/collision-event.ts
+++ b/lib/physics/collision-event.ts
@@ -55,12 +55,12 @@ export class CollisionEvent {
 	/**
 	 * Additional collision information
 	 */
-	public hitNormal: Vertex3D = new Vertex3D();
+	public readonly hitNormal: Vertex3D = new Vertex3D();
 
 	/**
 	 * Only "correctly" used by plunger and flipper
 	 */
-	public readonly hitVel: Vertex2D = new Vertex2D();
+	public hitVel: Vertex2D = new Vertex2D();
 
 	/**
 	 * Only set if isContact is true
@@ -94,8 +94,8 @@ export class CollisionEvent {
 	}
 
 	public static reset(event: CollisionEvent): void {
-		event.ball = undefined!;
-		event.obj = undefined;
+		delete event.ball;
+		delete event.obj;
 		event.isContact = false;
 		event.hitTime = 0;
 		event.hitDistance = 0;

--- a/lib/physics/collision-event.ts
+++ b/lib/physics/collision-event.ts
@@ -57,7 +57,7 @@ export class CollisionEvent {
 	/**
 	 * Only "correctly" used by plunger and flipper
 	 */
-	public hitVel?: Vertex2D;
+	public hitVel: Vertex2D = new Vertex2D();
 
 	/**
 	 * Only set if isContact is true

--- a/lib/physics/collision-event.ts
+++ b/lib/physics/collision-event.ts
@@ -57,7 +57,7 @@ export class CollisionEvent {
 	/**
 	 * Only "correctly" used by plunger and flipper
 	 */
-	public hitVel: Vertex2D = new Vertex2D();
+	public readonly hitVel: Vertex2D = new Vertex2D();
 
 	/**
 	 * Only set if isContact is true
@@ -88,8 +88,8 @@ export class CollisionEvent {
 		this.isContact = coll.isContact;
 		this.hitTime = coll.hitTime;
 		this.hitDistance = coll.hitDistance;
-		this.hitNormal = coll.hitNormal;
-		this.hitVel = coll.hitVel;
+		this.hitNormal.set(coll.hitNormal);
+		this.hitVel.set(coll.hitVel.x, coll.hitVel.y);
 		this.hitOrgNormalVelocity = coll.hitOrgNormalVelocity;
 		this.hitMomentBit = coll.hitMomentBit;
 		this.hitFlag = coll.hitFlag;

--- a/lib/physics/functions.ts
+++ b/lib/physics/functions.ts
@@ -15,4 +15,4 @@ export function elasticityWithFalloff(elasticity: number, falloff: number, vel: 
 	}
 }
 
-export const hardScatter = 0.0;
+export const HARD_SCATTER = 0.0;

--- a/lib/physics/hit-3dpoly.ts
+++ b/lib/physics/hit-3dpoly.ts
@@ -226,7 +226,7 @@ export class Hit3DPoly extends HitObject {
 		Vertex3D.release(hitPos);
 
 		if (crossCount & 1) {
-			coll.hitNormal = this.normal;
+			coll.hitNormal.set(this.normal);
 
 			if (!rigid) {                                                      // non rigid body collision? return direction
 				coll.hitFlag = bUnHit;                                         // UnHit signal is receding from outside target

--- a/lib/physics/hit-3dpoly.ts
+++ b/lib/physics/hit-3dpoly.ts
@@ -78,7 +78,7 @@ export class Hit3DPoly extends HitObject {
 
 	public collide(coll: CollisionEvent): void {
 		const ball = coll.ball;
-		const hitNormal = coll.hitNormal!;
+		const hitNormal = coll.hitNormal;
 
 		/* istanbul ignore else: This seems dead code to me. The actual trigger logic is handled in TriggerHitCircle and TriggerHitLine. */
 		if (this.objType !== CollisionType.Trigger) {

--- a/lib/physics/hit-3dpoly.ts
+++ b/lib/physics/hit-3dpoly.ts
@@ -24,7 +24,7 @@ import { Ball } from '../vpt/ball/ball';
 import { CollisionEvent } from './collision-event';
 import { CollisionType } from './collision-type';
 import { C_CONTACTVEL, C_LOWNORMVEL, PHYS_TOUCH, STATICTIME } from './constants';
-import { HitObject, HitTestResult } from './hit-object';
+import { HitObject } from './hit-object';
 
 export class Hit3DPoly extends HitObject {
 
@@ -111,15 +111,15 @@ export class Hit3DPoly extends HitObject {
 		}
 	}
 
-	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent): HitTestResult {
+	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent): number {
 		if (!this.isEnabled) {
-			return { hitTime: -1.0, coll };
+			return -1.0;
 		}
 
 		const bnv = this.normal.dot(ball.hit.vel);                                       // speed in Normal-vector direction
 
 		if ((this.objType !== CollisionType.Trigger) && (bnv > C_LOWNORMVEL)) {          // return if clearly ball is receding from object
-			return { hitTime: -1.0, coll };
+			return -1.0;
 		}
 
 		// Point on the ball that will hit the polygon, if it hits at all
@@ -138,7 +138,7 @@ export class Hit3DPoly extends HitObject {
 			if (bnd < -ball.data.radius) {
 				// (ball normal distance) excessive penetration of object skin ... no collision HACK //!! *2 necessary?
 				Vertex3D.release(hitPos);
-				return { hitTime: -1.0, coll };
+				return -1.0;
 			}
 
 			if (bnd <= PHYS_TOUCH) {
@@ -156,7 +156,7 @@ export class Hit3DPoly extends HitObject {
 
 			} else {
 				Vertex3D.release(hitPos);
-				return { hitTime: -1.0, coll };                                // wait for touching
+				return -1.0;                                // wait for touching
 			}
 		} else {                                                               // non-rigid polygon
 			if (bnv * bnd >= 0) {                                              // outside-receding || inside-approaching
@@ -164,7 +164,7 @@ export class Hit3DPoly extends HitObject {
 					|| Math.abs(bnd) >= ball.data.radius * 0.5                 // not too close ... nor too far away
 					|| inside !== ball.hit.vpVolObjs.indexOf(this.obj!) < 0) { // ...ball outside and hit set or ball inside and no hit set
 					Vertex3D.release(hitPos);
-					return { hitTime: -1.0, coll };
+					return -1.0;
 				}
 				hitTime = 0;
 				bUnHit = !inside;                                              // ball on outside is UnHit, otherwise it's a Hit
@@ -176,7 +176,7 @@ export class Hit3DPoly extends HitObject {
 
 		if (!isFinite(hitTime) || hitTime < 0 || hitTime > dTime) {            // time is outside this frame ... no collision
 			Vertex3D.release(hitPos);
-			return { hitTime: -1.0, coll };
+			return -1.0;
 		}
 
 		const adv = ball.hit.vel.clone(true).multiplyScalar(hitTime);
@@ -235,9 +235,9 @@ export class Hit3DPoly extends HitObject {
 			coll.hitDistance = bnd;                                            // 3dhit actual contact distance ...
 			//coll.m_hitRigid = rigid;                                         // collision type
 
-			return { hitTime, coll };
+			return hitTime;
 		}
 
-		return { hitTime: -1.0, coll };
+		return -1.0;
 	}
 }

--- a/lib/physics/hit-3dpoly.ts
+++ b/lib/physics/hit-3dpoly.ts
@@ -98,7 +98,7 @@ export class Hit3DPoly extends HitObject {
 			if (!coll.hitFlag === i < 0) { // Hit == NotAlreadyHit
 				const addPos = ball.hit.vel.clone(true).multiplyScalar(STATICTIME);
 				ball.state.pos.add(addPos);     // move ball slightly forward
-				addPos.release();
+				Vertex3D.release(addPos);
 				if (i < 0) {
 					ball.hit.vpVolObjs.push(this.obj!);
 					this.obj!.fireGroupEvent(Event.HitEventsHit);
@@ -127,8 +127,7 @@ export class Hit3DPoly extends HitObject {
 		const hitPos = ball.state.pos.clone(true).sub(normRadius);               // nearest point on ball ... projected radius along norm
 		const planeToBall = hitPos.clone(true).sub(this.rgv[0]);
 		const bnd = this.normal.dot(planeToBall);                                        // distance from plane to ball
-		normRadius.release();
-		planeToBall.release();
+		Vertex3D.release(normRadius, planeToBall);
 
 		let bUnHit = bnv > C_LOWNORMVEL;
 		const inside = bnd <= 0;                                                         // in ball inside object volume
@@ -138,7 +137,7 @@ export class Hit3DPoly extends HitObject {
 		if (rigid) {                                                                     // rigid polygon
 			if (bnd < -ball.data.radius) {
 				// (ball normal distance) excessive penetration of object skin ... no collision HACK //!! *2 necessary?
-				hitPos.release();
+				Vertex3D.release(hitPos);
 				return { hitTime: -1.0, coll };
 			}
 
@@ -156,7 +155,7 @@ export class Hit3DPoly extends HitObject {
 				hitTime = bnd / -bnv;                                          // rate ok for safe divide
 
 			} else {
-				hitPos.release();
+				Vertex3D.release(hitPos);
 				return { hitTime: -1.0, coll };                                // wait for touching
 			}
 		} else {                                                               // non-rigid polygon
@@ -164,7 +163,7 @@ export class Hit3DPoly extends HitObject {
 				if (!ball.hit.isRealBall()                                     // temporary ball
 					|| Math.abs(bnd) >= ball.data.radius * 0.5                 // not too close ... nor too far away
 					|| inside !== ball.hit.vpVolObjs.indexOf(this.obj!) < 0) { // ...ball outside and hit set or ball inside and no hit set
-					hitPos.release();
+					Vertex3D.release(hitPos);
 					return { hitTime: -1.0, coll };
 				}
 				hitTime = 0;
@@ -176,13 +175,13 @@ export class Hit3DPoly extends HitObject {
 		}
 
 		if (!isFinite(hitTime) || hitTime < 0 || hitTime > dTime) {            // time is outside this frame ... no collision
-			hitPos.release();
+			Vertex3D.release(hitPos);
 			return { hitTime: -1.0, coll };
 		}
 
 		const adv = ball.hit.vel.clone(true).multiplyScalar(hitTime);
 		hitPos.add(adv);              // advance hit point to contact
-		adv.release();
+		Vertex3D.release(adv);
 
 		// Do a point in poly test, using the xy plane, to see if the hit point is inside the polygon
 		// this need to be changed to a point in polygon on 3D plane
@@ -224,7 +223,7 @@ export class Hit3DPoly extends HitObject {
 				crossCount ^= 1;
 			}
 		}
-		hitPos.release();
+		Vertex3D.release(hitPos);
 
 		if (crossCount & 1) {
 			coll.hitNormal = this.normal;

--- a/lib/physics/hit-3dpoly.ts
+++ b/lib/physics/hit-3dpoly.ts
@@ -29,13 +29,12 @@ import { HitObject, HitTestResult } from './hit-object';
 export class Hit3DPoly extends HitObject {
 
 	private readonly rgv: Vertex3D[];
-	private readonly normal: Vertex3D;
+	private readonly normal: Vertex3D = new Vertex3D();
 
 	constructor(rgv: Vertex3D[], objType?: CollisionType) {
 		super();
 
 		this.rgv = rgv;
-		this.normal = new Vertex3D();
 		if (objType) {
 			this.objType = objType;
 		}

--- a/lib/physics/hit-circle.ts
+++ b/lib/physics/hit-circle.ts
@@ -41,7 +41,7 @@ export class HitCircle extends HitObject {
 	}
 
 	public collide(coll: CollisionEvent, physics: PlayerPhysics): void {
-		coll.ball.hit.collide3DWall(coll.hitNormal!, this.elasticity, this.elasticityFalloff, this.friction, this.scatter);
+		coll.ball.hit.collide3DWall(coll.hitNormal, this.elasticity, this.elasticityFalloff, this.friction, this.scatter);
 	}
 
 	public calcHitBBox(): void {

--- a/lib/physics/hit-circle.ts
+++ b/lib/physics/hit-circle.ts
@@ -89,26 +89,23 @@ export class HitCircle extends HitObject {
 		const bcddsq = dist.lengthSq();             // ball center to circle center distance ... squared
 		const bcdd = Math.sqrt(bcddsq);             // distance center to center
 		if (bcdd <= 1.0e-6) {
-			dist.release();
-			dv.release();
-			c.release();
+			Vertex3D.release(dist, dv, c);
 			return { hitTime: -1.0, coll };         // no hit on exact center
 		}
 
 		const b = dist.dot(dv);
 		const bnv = b / bcdd;                       // ball normal velocity
-		dist.release();
+		Vertex3D.release(dist);
 
 		if (direction && bnv > C_LOWNORMVEL) {
-			dv.release();
-			c.release();
+			Vertex3D.release(dv, c);
 			return { hitTime: -1.0, coll };         // clearly receding from radius
 		}
 
 		const bnd = bcdd - targetRadius;            // ball normal distance to
 
 		const a = dv.lengthSq();
-		dv.release();
+		Vertex3D.release(dv);
 
 		let hitTime = 0;
 		let isUnhit = false;
@@ -124,7 +121,7 @@ export class HitCircle extends HitObject {
 		// positive: contact possible in future ... Negative: objects in contact now
 		if (rigid && bnd < PHYS_TOUCH) {
 			if (bnd < -ball.data.radius) {
-				c.release();
+				Vertex3D.release(c);
 				return { hitTime: -1.0, coll };
 
 			} else if (Math.abs(bnv) <= C_CONTACTVEL) {
@@ -151,13 +148,13 @@ export class HitCircle extends HitObject {
 		} else {
 			if ((!rigid && bnd * bnv > 0) || (a < 1.0e-8)) { // (outside and receding) or (inside and approaching)
 				// no hit ... ball not moving relative to object
-				c.release();
+				Vertex3D.release(c);
 				return { hitTime: -1.0, coll };
 			}
 
 			const sol = solveQuadraticEq(a, 2.0 * b, bcddsq - targetRadius * targetRadius);
 			if (!sol) {
-				c.release();
+				Vertex3D.release(c);
 				return { hitTime: -1.0, coll };
 			}
 			const [time1, time2] = sol;
@@ -167,7 +164,7 @@ export class HitCircle extends HitObject {
 
 		if (!isFinite(hitTime) || hitTime < 0 || hitTime > dTime) {
 			// contact out of physics frame
-			c.release();
+			Vertex3D.release(c);
 			return { hitTime: -1.0, coll };
 		}
 
@@ -175,7 +172,7 @@ export class HitCircle extends HitObject {
 		if (hitZ + ball.data.radius * 0.5 < this.hitBBox.zlow
 			|| !capsule3D && (hitZ - ball.data.radius * 0.5) > this.hitBBox.zhigh
 			|| capsule3D && hitZ < this.hitBBox.zhigh) {
-			c.release();
+			Vertex3D.release(c);
 			return { hitTime: -1.0, coll };
 		}
 
@@ -196,7 +193,7 @@ export class HitCircle extends HitObject {
 			coll.hitNormal.y = 1.0;
 			coll.hitNormal.z = 0.0;
 		}
-		c.release();
+		Vertex3D.release(c);
 
 		if (!rigid) {                                      // non rigid body collision? return direction
 			coll.hitFlag = isUnhit;                        // UnHit signal is receding from target

--- a/lib/physics/hit-circle.ts
+++ b/lib/physics/hit-circle.ts
@@ -64,8 +64,8 @@ export class HitCircle extends HitObject {
 		}
 
 		const c = new Vertex3D(this.center.x, this.center.y, 0.0);
-		const dist = ball.state.pos.clone().sub(c);    // relative ball position
-		const dv = ball.hit.vel.clone();
+		const dist = ball.state.pos.clone(true).sub(c);    // relative ball position
+		const dv = ball.hit.vel.clone(true);
 
 		const capsule3D = !lateral && ball.state.pos.z > this.hitBBox.zhigh;
 		const isKicker = this.objType === CollisionType.Kicker;
@@ -89,19 +89,24 @@ export class HitCircle extends HitObject {
 		const bcddsq = dist.lengthSq();             // ball center to circle center distance ... squared
 		const bcdd = Math.sqrt(bcddsq);             // distance center to center
 		if (bcdd <= 1.0e-6) {
+			dist.release();
+			dv.release();
 			return { hitTime: -1.0, coll };         // no hit on exact center
 		}
 
 		const b = dist.dot(dv);
 		const bnv = b / bcdd;                       // ball normal velocity
+		dist.release();
 
 		if (direction && bnv > C_LOWNORMVEL) {
+			dv.release();
 			return { hitTime: -1.0, coll };         // clearly receding from radius
 		}
 
 		const bnd = bcdd - targetRadius;            // ball normal distance to
 
 		const a = dv.lengthSq();
+		dv.release();
 
 		let hitTime = 0;
 		let isUnhit = false;

--- a/lib/physics/hit-kd-node.ts
+++ b/lib/physics/hit-kd-node.ts
@@ -100,7 +100,7 @@ export class HitKDNode {
 			return;
 		}
 
-		const vDiag = new Vertex3D(
+		const vDiag = Vertex3D.claim(
 			this.rectBounds.right - this.rectBounds.left,
 			this.rectBounds.bottom - this.rectBounds.top,
 			this.rectBounds.zhigh - this.rectBounds.zlow,
@@ -109,22 +109,26 @@ export class HitKDNode {
 		let axis: number;
 		if (vDiag.x > vDiag.y && vDiag.x > vDiag.z) {
 			if (vDiag.x < 0.0001) { //!! magic
+				vDiag.release();
 				return;
 			}
 			axis = 0;
 
 		} else if (vDiag.y > vDiag.z) {
 			if (vDiag.y < 0.0001) { //!!
+				vDiag.release();
 				return;
 			}
 			axis = 1;
 
 		} else {
 			if (vDiag.z < 0.0001) { //!!
+				vDiag.release();
 				return;
 			}
 			axis = 2;
 		}
+		vDiag.release();
 
 		//!! weight this with ratio of elements going to middle vs left&right! (avoids volume split that goes directly through object)
 
@@ -137,7 +141,7 @@ export class HitKDNode {
 		this.children[0].rectBounds = this.rectBounds;
 		this.children[1].rectBounds = this.rectBounds;
 
-		const vCenter = new Vertex3D(
+		const vCenter = Vertex3D.claim(
 			(this.rectBounds.left + this.rectBounds.right) * 0.5,
 			(this.rectBounds.top + this.rectBounds.bottom) * 0.5,
 			(this.rectBounds.zlow + this.rectBounds.zhigh) * 0.5,
@@ -222,6 +226,7 @@ export class HitKDNode {
 		if (levelEmpty > 8) {// If 8 levels were all just subdividing the same objects without luck, exit & Free the nodes again (but at least empty space was cut off)
 			this.hitOct.numNodes -= 2;
 			this.children = [];
+			vCenter.release();
 			return;
 		}
 
@@ -271,6 +276,7 @@ export class HitKDNode {
 				}
 			}
 		}
+		vCenter.release();
 		// The following assertions hold after this step:
 		//assert( this.start + items == this.children[0].this.start );
 		//assert( this.children[0].this.start + this.children[0].this.items == this.children[1].this.start );

--- a/lib/physics/hit-kd-node.ts
+++ b/lib/physics/hit-kd-node.ts
@@ -46,7 +46,7 @@ export class HitKDNode {
 		this.items = 0;
 	}
 
-	public hitTestBall(ball: Ball, coll: CollisionEvent, physics: PlayerPhysics): CollisionEvent {
+	public hitTestBall(ball: Ball, coll: CollisionEvent, physics: PlayerPhysics): void {
 
 		const orgItems = this.items & 0x3FFFFFFF;
 		const axis = this.items >> 30;
@@ -54,7 +54,7 @@ export class HitKDNode {
 		for (let i = this.start; i < this.start + orgItems; i++) {
 			const pho = this.hitOct.getItemAt(i);
 			if (ball.hit !== pho && pho.hitBBox.intersectSphere(ball.state.pos, ball.hit.rcHitRadiusSqr)) {
-				coll = pho.doHitTest(ball, coll, physics);
+				pho.doHitTest(ball, coll, physics);
 			}
 		}
 
@@ -63,39 +63,38 @@ export class HitKDNode {
 			if (axis === 0) {
 				const vCenter = (this.rectBounds.left + this.rectBounds.right) * 0.5;
 				if (ball.hit.hitBBox.left <= vCenter) {
-					coll = this.children[0].hitTestBall(ball, coll, physics);
+					this.children[0].hitTestBall(ball, coll, physics);
 				}
 				if (ball.hit.hitBBox.right >= vCenter) {
-					coll = this.children[1].hitTestBall(ball, coll, physics);
+					this.children[1].hitTestBall(ball, coll, physics);
 				}
 
 			} else if (axis === 1) {
 				const vCenter = (this.rectBounds.top + this.rectBounds.bottom) * 0.5;
 				if (ball.hit.hitBBox.top <= vCenter) {
-					coll = this.children[0].hitTestBall(ball, coll, physics);
+					this.children[0].hitTestBall(ball, coll, physics);
 				}
 				if (ball.hit.hitBBox.bottom >= vCenter) {
-					coll = this.children[1].hitTestBall(ball, coll, physics);
+					this.children[1].hitTestBall(ball, coll, physics);
 				}
 
 			} else {
 				const vCenter = (this.rectBounds.zlow + this.rectBounds.zhigh) * 0.5;
 				if (ball.hit.hitBBox.zlow <= vCenter) {
-					coll = this.children[0].hitTestBall(ball, coll, physics);
+					this.children[0].hitTestBall(ball, coll, physics);
 				}
 				if (ball.hit.hitBBox.zhigh >= vCenter) {
-					coll = this.children[1].hitTestBall(ball, coll, physics);
+					this.children[1].hitTestBall(ball, coll, physics);
 				}
 			}
 		}
-		return coll;
 	}
 
 	/* istanbul ignore next: never executed below the "magic" check (https://www.vpforums.org/index.php?showtopic=42690) */
 	public createNextLevel(level: number, levelEmpty: number): void {
 		const orgItems = (this.items & 0x3FFFFFFF);
 
-		//!! magic
+		// !! magic
 		if (orgItems <= 4 || level >= 128 / 2) {
 			return;
 		}

--- a/lib/physics/hit-kd-node.ts
+++ b/lib/physics/hit-kd-node.ts
@@ -40,7 +40,7 @@ export class HitKDNode {
 	}
 
 	public reset(hitOct: HitKD) {
-		this.children = [];
+		this.children.length = 0;
 		this.hitOct = hitOct;
 		this.start = 0;
 		this.items = 0;
@@ -160,10 +160,10 @@ export class HitKDNode {
 
 		this.children[0].hitOct = this.hitOct; //!! meh
 		this.children[0].items = 0;
-		this.children[0].children = [];
+		this.children[0].children.length = 0;
 		this.children[1].hitOct = this.hitOct; //!! meh
 		this.children[1].items = 0;
-		this.children[1].children = [];
+		this.children[1].children.length = 0;
 
 		// determine amount of items that cross splitplane, or are passed on to the children
 		if (axis === 0) {
@@ -224,7 +224,7 @@ export class HitKDNode {
 
 		if (levelEmpty > 8) {// If 8 levels were all just subdividing the same objects without luck, exit & Free the nodes again (but at least empty space was cut off)
 			this.hitOct.numNodes -= 2;
-			this.children = [];
+			this.children.length = 0;
 			Vertex3D.release(vCenter);
 			return;
 		}

--- a/lib/physics/hit-kd-node.ts
+++ b/lib/physics/hit-kd-node.ts
@@ -109,26 +109,26 @@ export class HitKDNode {
 		let axis: number;
 		if (vDiag.x > vDiag.y && vDiag.x > vDiag.z) {
 			if (vDiag.x < 0.0001) { //!! magic
-				vDiag.release();
+				Vertex3D.release(vDiag);
 				return;
 			}
 			axis = 0;
 
 		} else if (vDiag.y > vDiag.z) {
 			if (vDiag.y < 0.0001) { //!!
-				vDiag.release();
+				Vertex3D.release(vDiag);
 				return;
 			}
 			axis = 1;
 
 		} else {
 			if (vDiag.z < 0.0001) { //!!
-				vDiag.release();
+				Vertex3D.release(vDiag);
 				return;
 			}
 			axis = 2;
 		}
-		vDiag.release();
+		Vertex3D.release(vDiag);
 
 		//!! weight this with ratio of elements going to middle vs left&right! (avoids volume split that goes directly through object)
 
@@ -226,7 +226,7 @@ export class HitKDNode {
 		if (levelEmpty > 8) {// If 8 levels were all just subdividing the same objects without luck, exit & Free the nodes again (but at least empty space was cut off)
 			this.hitOct.numNodes -= 2;
 			this.children = [];
-			vCenter.release();
+			Vertex3D.release(vCenter);
 			return;
 		}
 
@@ -276,7 +276,7 @@ export class HitKDNode {
 				}
 			}
 		}
-		vCenter.release();
+		Vertex3D.release(vCenter);
 		// The following assertions hold after this step:
 		//assert( this.start + items == this.children[0].this.start );
 		//assert( this.children[0].this.start + this.children[0].this.items == this.children[1].this.start );

--- a/lib/physics/hit-kd.ts
+++ b/lib/physics/hit-kd.ts
@@ -87,8 +87,8 @@ export class HitKD {
 		this.tmp = [];
 	}
 
-	public hitTestBall(pball: Ball, collision: CollisionEvent, physics: PlayerPhysics): CollisionEvent {
-		return this.rootNode.hitTestBall(pball, collision, physics);
+	public hitTestBall(ball: Ball, collision: CollisionEvent, physics: PlayerPhysics) {
+		this.rootNode.hitTestBall(ball, collision, physics);
 	}
 
 	// public hitTestXRay(pball: Ball, pvhoHit: HitObject[], coll: CollisionEvent, player: Player) {

--- a/lib/physics/hit-line-3d.ts
+++ b/lib/physics/hit-line-3d.ts
@@ -95,7 +95,7 @@ export class HitLine3D extends HitLineZ {
 		this.hitBBox.zhigh = oldZ.y;  // dto.
 
 		if (hitTime >= 0) {      // transform hit normal back to world coordinate system
-			coll.hitNormal = this.matrix.multiplyVectorT(coll.hitNormal!);
+			coll.hitNormal.setAndRelease(this.matrix.multiplyVectorT(coll.hitNormal, true));
 		}
 
 		Vertex2D.release(oldZ);
@@ -105,7 +105,7 @@ export class HitLine3D extends HitLineZ {
 
 	public collide(coll: CollisionEvent): void {
 		const ball = coll.ball;
-		const hitNormal = coll.hitNormal!;
+		const hitNormal = coll.hitNormal;
 
 		const dot = -hitNormal.dot(ball.hit.vel);
 		ball.hit.collide3DWall(hitNormal, this.elasticity, this.elasticityFalloff, this.friction, this.scatter);

--- a/lib/physics/hit-line-3d.ts
+++ b/lib/physics/hit-line-3d.ts
@@ -23,7 +23,6 @@ import { Vertex3D } from '../math/vertex3d';
 import { Ball } from '../vpt/ball/ball';
 import { CollisionEvent } from './collision-event';
 import { HitLineZ } from './hit-line-z';
-import { HitTestResult } from './hit-object';
 
 export class HitLine3D extends HitLineZ {
 
@@ -73,9 +72,9 @@ export class HitLine3D extends HitLineZ {
 		// already one in constructor
 	}
 
-	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent): HitTestResult {
+	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent): number {
 		if (!this.isEnabled) {
-			return { hitTime: -1.0, coll };
+			return -1.0;
 		}
 		// transform ball to cylinder coordinate system
 		const oldPos = ball.state.pos.clone(true);
@@ -88,8 +87,7 @@ export class HitLine3D extends HitLineZ {
 		this.hitBBox.zlow = this.zLow;   // HACK; needed below // evil cast to non-const, should actually change the stupid HitLineZ to have explicit z coordinates!
 		this.hitBBox.zhigh = this.zHigh; // dto.
 
-		let hitTime: number;
-		({ hitTime, coll } = super.hitTest(ball, dTime, coll));
+		const hitTime = super.hitTest(ball, dTime, coll);
 
 		ball.state.pos.set(oldPos.x, oldPos.y, oldPos.z); // see above
 		ball.hit.vel.set(oldVel.x, oldVel.y, oldVel.z);
@@ -102,7 +100,7 @@ export class HitLine3D extends HitLineZ {
 
 		Vertex2D.release(oldZ);
 		Vertex3D.release(oldPos, oldVel);
-		return { hitTime, coll };
+		return hitTime;
 	}
 
 	public collide(coll: CollisionEvent): void {

--- a/lib/physics/hit-line-3d.ts
+++ b/lib/physics/hit-line-3d.ts
@@ -55,7 +55,7 @@ export class HitLine3D extends HitLineZ {
 		const vTrans2z = vTrans2.z;
 
 		// set up HitLineZ parameters
-		this.xy = new Vertex2D(vTrans1.x, vTrans1.y);
+		this.xy.set(vTrans1.x, vTrans1.y);
 		this.zLow = Math.min(vTrans1.z, vTrans2z);
 		this.zHigh = Math.max(vTrans1.z, vTrans2z);
 
@@ -87,7 +87,7 @@ export class HitLine3D extends HitLineZ {
 		ball.state.pos.applyMatrix2D(this.matrix);
 
 		// and update z bounds of LineZ with transformed coordinates
-		const oldZ = new Vertex2D(this.hitBBox.zlow, this.hitBBox.zhigh);
+		const oldZ = Vertex2D.claim(this.hitBBox.zlow, this.hitBBox.zhigh);
 		this.hitBBox.zlow = this.zLow;   // HACK; needed below // evil cast to non-const, should actually change the stupid HitLineZ to have explicit z coordinates!
 		this.hitBBox.zhigh = this.zHigh; // dto.
 
@@ -103,6 +103,7 @@ export class HitLine3D extends HitLineZ {
 			coll.hitNormal = this.matrix.multiplyVectorT(coll.hitNormal!);
 		}
 
+		oldZ.release();
 		oldPos.release();
 		oldVel.release();
 		return { hitTime, coll };

--- a/lib/physics/hit-line-3d.ts
+++ b/lib/physics/hit-line-3d.ts
@@ -66,10 +66,7 @@ export class HitLine3D extends HitLineZ {
 		this.hitBBox.zlow = Math.min(v1.z, v2.z);
 		this.hitBBox.zhigh = Math.max(v1.z, v2.z);
 
-		vTrans1.release();
-		vTrans2.release();
-		transAxis.release();
-		vLine.release();
+		Vertex3D.release(vTrans1, vTrans2, transAxis, vLine);
 	}
 
 	public calcHitBBox(): void {
@@ -103,9 +100,8 @@ export class HitLine3D extends HitLineZ {
 			coll.hitNormal = this.matrix.multiplyVectorT(coll.hitNormal!);
 		}
 
-		oldZ.release();
-		oldPos.release();
-		oldVel.release();
+		Vertex2D.release(oldZ);
+		Vertex3D.release(oldPos, oldVel);
 		return { hitTime, coll };
 	}
 

--- a/lib/physics/hit-line-z.ts
+++ b/lib/physics/hit-line-z.ts
@@ -139,8 +139,8 @@ export class HitLineZ extends HitObject {
 	}
 
 	public collide(coll: CollisionEvent): void {
-		const dot = coll.hitNormal!.dot(coll.ball.hit.vel);
-		coll.ball.hit.collide3DWall(coll.hitNormal!, this.elasticity, this.elasticityFalloff, this.friction, this.scatter);
+		const dot = coll.hitNormal.dot(coll.ball.hit.vel);
+		coll.ball.hit.collide3DWall(coll.hitNormal, this.elasticity, this.elasticityFalloff, this.friction, this.scatter);
 
 		if (dot <= -this.threshold) {
 			this.fireHitEvent(coll.ball);

--- a/lib/physics/hit-line-z.ts
+++ b/lib/physics/hit-line-z.ts
@@ -19,11 +19,10 @@
 
 import { solveQuadraticEq } from '../math/functions';
 import { Vertex2D } from '../math/vertex2d';
-import { Vertex3D } from '../math/vertex3d';
 import { Ball } from '../vpt/ball/ball';
 import { CollisionEvent } from './collision-event';
 import { C_CONTACTVEL, PHYS_TOUCH } from './constants';
-import { HitObject, HitTestResult } from './hit-object';
+import { HitObject } from './hit-object';
 
 export class HitLineZ extends HitObject {
 
@@ -55,9 +54,9 @@ export class HitLineZ extends HitObject {
 		// zlow and zhigh set in ctor
 	}
 
-	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent): HitTestResult {
+	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent): number {
 		if (!this.isEnabled) {
-			return { hitTime: -1.0, coll };
+			return -1.0;
 		}
 
 		const bp2d = Vertex2D.claim(ball.state.pos.x, ball.state.pos.y);
@@ -69,7 +68,7 @@ export class HitLineZ extends HitObject {
 		const bcdd = Math.sqrt(bcddsq);                    // distance ball to line
 		if (bcdd <= 1.0e-6) {
 			Vertex2D.release(dv, dist);
-			return { hitTime: -1.0, coll };                // no hit on exact center
+			return -1.0;                // no hit on exact center
 		}
 
 		const b = dist.dot(dv);
@@ -78,7 +77,7 @@ export class HitLineZ extends HitObject {
 
 		if (bnv > C_CONTACTVEL) {
 			Vertex2D.release(dv);
-			return { hitTime: -1.0, coll };                // clearly receding from radius
+			return -1.0;                // clearly receding from radius
 		}
 
 		const bnd = bcdd - ball.data.radius;               // ball distance to line
@@ -98,11 +97,11 @@ export class HitLineZ extends HitObject {
 			}
 		} else {
 			if (a < 1.0e-8) {
-				return { hitTime: -1.0, coll };            // no hit - ball not moving relative to object
+				return -1.0;            // no hit - ball not moving relative to object
 			}
 			const sol = solveQuadraticEq(a, 2.0 * b, bcddsq - ball.data.radius * ball.data.radius);
 			if (!sol) {
-				return { hitTime: -1.0, coll };
+				return -1.0;
 			}
 			const time1 = sol[0];
 			const time2 = sol[1];
@@ -112,13 +111,13 @@ export class HitLineZ extends HitObject {
 		}
 
 		if (!isFinite(hitTime) || hitTime < 0 || hitTime > dTime) {
-			return { hitTime: -1.0, coll };                                    // contact out of physics frame
+			return -1.0;                                    // contact out of physics frame
 		}
 
 		const hitZ = ball.state.pos.z + hitTime * ball.hit.vel.z;              // ball z position at hit time
 
 		if (hitZ < this.hitBBox.zlow || hitZ > this.hitBBox.zhigh) {           // check z coordinate
-			return { hitTime: -1.0, coll };
+			return -1.0;
 		}
 
 		const hitX = ball.state.pos.x + hitTime * ball.hit.vel.x;              // ball x position at hit time
@@ -136,7 +135,7 @@ export class HitLineZ extends HitObject {
 		coll.hitDistance = bnd;                                                // actual contact distance
 		//coll.m_hitRigid = true;
 
-		return { hitTime, coll };
+		return hitTime;
 	}
 
 	public collide(coll: CollisionEvent): void {

--- a/lib/physics/hit-line-z.ts
+++ b/lib/physics/hit-line-z.ts
@@ -63,28 +63,27 @@ export class HitLineZ extends HitObject {
 		const bp2d = Vertex2D.claim(ball.state.pos.x, ball.state.pos.y);
 		const dist = bp2d.clone(true).sub(this.xy);            // relative ball position
 		const dv = Vertex2D.claim(ball.hit.vel.x, ball.hit.vel.y);
-		bp2d.release();
+		Vertex2D.release(bp2d);
 
 		const bcddsq = dist.lengthSq();                    // ball center to line distance squared
 		const bcdd = Math.sqrt(bcddsq);                    // distance ball to line
 		if (bcdd <= 1.0e-6) {
-			dv.release();
-			dist.release();
+			Vertex2D.release(dv, dist);
 			return { hitTime: -1.0, coll };                // no hit on exact center
 		}
 
 		const b = dist.dot(dv);
 		const bnv = b / bcdd;                              // ball normal velocity
-		dist.release();
+		Vertex2D.release(dist);
 
 		if (bnv > C_CONTACTVEL) {
-			dv.release();
+			Vertex2D.release(dv);
 			return { hitTime: -1.0, coll };                // clearly receding from radius
 		}
 
 		const bnd = bcdd - ball.data.radius;               // ball distance to line
 		const a = dv.lengthSq();
-		dv.release();
+		Vertex2D.release(dv);
 
 		let hitTime = 0;
 		let isContact = false;
@@ -127,7 +126,7 @@ export class HitLineZ extends HitObject {
 
 		const norm = Vertex2D.claim(hitX - this.xy.x, hitY - this.xy.y).normalize();
 		coll.hitNormal.set(norm.x, norm.y, 0.0);
-		norm.release();
+		Vertex2D.release(norm);
 
 		coll.isContact = isContact;
 		if (isContact) {

--- a/lib/physics/hit-line-z.ts
+++ b/lib/physics/hit-line-z.ts
@@ -60,25 +60,31 @@ export class HitLineZ extends HitObject {
 			return { hitTime: -1.0, coll };
 		}
 
-		const bp2d = new Vertex2D(ball.state.pos.x, ball.state.pos.y);
-		const dist = bp2d.clone().sub(this.xy);            // relative ball position
-		const dv = new Vertex2D(ball.hit.vel.x, ball.hit.vel.y);
+		const bp2d = Vertex2D.claim(ball.state.pos.x, ball.state.pos.y);
+		const dist = bp2d.clone(true).sub(this.xy);            // relative ball position
+		const dv = Vertex2D.claim(ball.hit.vel.x, ball.hit.vel.y);
+		bp2d.release();
 
 		const bcddsq = dist.lengthSq();                    // ball center to line distance squared
 		const bcdd = Math.sqrt(bcddsq);                    // distance ball to line
 		if (bcdd <= 1.0e-6) {
+			dv.release();
+			dist.release();
 			return { hitTime: -1.0, coll };                // no hit on exact center
 		}
 
 		const b = dist.dot(dv);
 		const bnv = b / bcdd;                              // ball normal velocity
+		dist.release();
 
 		if (bnv > C_CONTACTVEL) {
+			dv.release();
 			return { hitTime: -1.0, coll };                // clearly receding from radius
 		}
 
 		const bnd = bcdd - ball.data.radius;               // ball distance to line
 		const a = dv.lengthSq();
+		dv.release();
 
 		let hitTime = 0;
 		let isContact = false;
@@ -119,9 +125,9 @@ export class HitLineZ extends HitObject {
 		const hitX = ball.state.pos.x + hitTime * ball.hit.vel.x;              // ball x position at hit time
 		const hitY = ball.state.pos.y + hitTime * ball.hit.vel.y;              // ball y position at hit time
 
-		const norm = new Vertex2D(hitX - this.xy.x, hitY - this.xy.y);
-		norm.normalize();
-		coll.hitNormal = new Vertex3D(norm.x, norm.y, 0.0);
+		const norm = Vertex2D.claim(hitX - this.xy.x, hitY - this.xy.y).normalize();
+		coll.hitNormal.set(norm.x, norm.y, 0.0);
+		norm.release();
 
 		coll.isContact = isContact;
 		if (isContact) {

--- a/lib/physics/hit-object.ts
+++ b/lib/physics/hit-object.ts
@@ -23,11 +23,11 @@ import { EventProxy } from '../game/event-proxy';
 import { PlayerPhysics } from '../game/player-physics';
 import { degToRad } from '../math/float';
 import { FRect3D } from '../math/frect3d';
+import { Vertex3D } from '../math/vertex3d';
 import { Ball } from '../vpt/ball/ball';
 import { IPhysicalData } from '../vpt/item-data';
 import { CollisionEvent } from './collision-event';
 import { CollisionType } from './collision-type';
-import { Vertex3D } from '../math/vertex3d';
 
 export abstract class HitObject {
 
@@ -63,7 +63,7 @@ export abstract class HitObject {
 
 	public abstract calcHitBBox(): void;
 
-	public abstract hitTest(ball: Ball, dTime: number, coll: CollisionEvent, physics: PlayerPhysics): HitTestResult;
+	public abstract hitTest(ball: Ball, dTime: number, coll: CollisionEvent, physics: PlayerPhysics): number;
 
 	public abstract collide(coll: CollisionEvent, physics: PlayerPhysics): void;
 
@@ -139,14 +139,8 @@ export abstract class HitObject {
 			return coll;
 		}
 
-		let newColl = new CollisionEvent(ball);
-		const hitResult = this.hitTest(ball, coll.hitTime, !physics.recordContacts ? coll : newColl, physics);
-		const newTime = hitResult.hitTime;
-		if (!physics.recordContacts) {
-			coll = hitResult.coll;
-		} else {
-			newColl = hitResult.coll;
-		}
+		const newColl = new CollisionEvent(ball);
+		const newTime = this.hitTest(ball, coll.hitTime, !physics.recordContacts ? coll : newColl, physics);
 		const validHit = newTime >= 0 && newTime <= coll.hitTime;
 
 		if (!physics.recordContacts) {            // simply find first event
@@ -187,9 +181,4 @@ export abstract class HitObject {
 
 		this.setEnabled(data.isCollidable);
 	}
-}
-
-export interface HitTestResult {
-	hitTime: number;
-	coll: CollisionEvent;
 }

--- a/lib/physics/hit-object.ts
+++ b/lib/physics/hit-object.ts
@@ -70,12 +70,12 @@ export abstract class HitObject {
 	/**
 	 * apply contact forces for the given time interval. Ball, Spinner and Gate do nothing here, Flipper has a specialized handling
 	 * @param coll
-	 * @param dtime
+	 * @param dTime
 	 * @param physics
 	 * @constructor
 	 */
-	public contact(coll: CollisionEvent, dtime: number, physics: PlayerPhysics): void {
-		coll.ball.hit.handleStaticContact(coll, this.friction, dtime, physics);
+	public contact(coll: CollisionEvent, dTime: number, physics: PlayerPhysics): void {
+		coll.ball.hit.handleStaticContact(coll, this.friction, dTime, physics);
 	}
 
 	public setFriction(friction: number): this {
@@ -139,7 +139,7 @@ export abstract class HitObject {
 			return;
 		}
 
-		const newColl = new CollisionEvent(ball);
+		const newColl = CollisionEvent.claim(ball);
 		const newTime = this.hitTest(ball, coll.hitTime, !physics.recordContacts ? coll : newColl, physics);
 		const validHit = newTime >= 0 && newTime <= coll.hitTime;
 
@@ -149,6 +149,7 @@ export abstract class HitObject {
 				coll.obj = this;
 				coll.hitTime = newTime;
 			}
+			CollisionEvent.release(newColl);
 
 		} else {                                 // find first collision, but also remember all contacts
 			if (newColl.isContact || validHit) {
@@ -160,8 +161,10 @@ export abstract class HitObject {
 				} else {                         // if (validhit)
 					coll.set(newColl);
 					coll.hitTime = newTime;
-					//CollisionEvent.release(newColl);
+					CollisionEvent.release(newColl);
 				}
+			} else {
+				CollisionEvent.release(newColl);
 			}
 		}
 	}

--- a/lib/physics/hit-object.ts
+++ b/lib/physics/hit-object.ts
@@ -91,7 +91,9 @@ export abstract class HitObject {
 		if (this.obj && this.fe && this.isEnabled) {
 
 			// is this the same place as last event? if same then ignore it
-			const distLs = (ball.hit.eventPos.clone().sub(ball.state.pos)).lengthSq();
+			const posDiff = ball.hit.eventPos.clone(true).sub(ball.state.pos);
+			const distLs = posDiff.lengthSq();
+			posDiff.release();
 
 			// remember last collide position
 			ball.hit.eventPos.set(ball.state.pos.x, ball.state.pos.y, ball.state.pos.z);

--- a/lib/physics/hit-object.ts
+++ b/lib/physics/hit-object.ts
@@ -130,13 +130,13 @@ export abstract class HitObject {
 		this.objType = type;
 	}
 
-	public doHitTest(ball: Ball, coll: CollisionEvent, physics: PlayerPhysics): CollisionEvent {
+	public doHitTest(ball: Ball, coll: CollisionEvent, physics: PlayerPhysics): void {
 		if (!ball) {
-			return coll;
+			return;
 		}
 
 		if (this.obj && this.obj.abortHitTest && this.obj.abortHitTest()) {
-			return coll;
+			return;
 		}
 
 		const newColl = new CollisionEvent(ball);
@@ -157,13 +157,13 @@ export abstract class HitObject {
 
 				if (newColl.isContact) {
 					physics.contacts.push(newColl);
-				} else { //if (validhit)
-					coll = newColl;
+				} else {                         // if (validhit)
+					coll.set(newColl);
 					coll.hitTime = newTime;
+					//CollisionEvent.release(newColl);
 				}
 			}
 		}
-		return coll;
 	}
 
 	public applyPhysics(data: IPhysicalData, table: Table) {

--- a/lib/physics/hit-object.ts
+++ b/lib/physics/hit-object.ts
@@ -27,6 +27,7 @@ import { Ball } from '../vpt/ball/ball';
 import { IPhysicalData } from '../vpt/item-data';
 import { CollisionEvent } from './collision-event';
 import { CollisionType } from './collision-type';
+import { Vertex3D } from '../math/vertex3d';
 
 export abstract class HitObject {
 
@@ -93,7 +94,7 @@ export abstract class HitObject {
 			// is this the same place as last event? if same then ignore it
 			const posDiff = ball.hit.eventPos.clone(true).sub(ball.state.pos);
 			const distLs = posDiff.lengthSq();
-			posDiff.release();
+			Vertex3D.release(posDiff);
 
 			// remember last collide position
 			ball.hit.eventPos.set(ball.state.pos.x, ball.state.pos.y, ball.state.pos.z);

--- a/lib/physics/hit-object.ts
+++ b/lib/physics/hit-object.ts
@@ -158,6 +158,7 @@ export abstract class HitObject {
 
 				if (newColl.isContact) {
 					physics.contacts.push(newColl);
+
 				} else {                         // if (validhit)
 					coll.set(newColl);
 					coll.hitTime = newTime;

--- a/lib/physics/hit-plane.ts
+++ b/lib/physics/hit-plane.ts
@@ -87,7 +87,7 @@ export class HitPlane extends HitObject {
 	}
 
 	public collide(coll: CollisionEvent): void {
-		coll.ball.hit.collide3DWall(coll.hitNormal!, this.elasticity, this.elasticityFalloff, this.friction, this.scatter);
+		coll.ball.hit.collide3DWall(coll.hitNormal, this.elasticity, this.elasticityFalloff, this.friction, this.scatter);
 
 		// distance from plane to ball surface
 		const bnd = this.normal.dot(coll.ball.state.pos) - coll.ball.data.radius - this.d;

--- a/lib/physics/hit-plane.ts
+++ b/lib/physics/hit-plane.ts
@@ -61,7 +61,7 @@ export class HitPlane extends HitObject {
 		if (Math.abs(bnv) <= C_CONTACTVEL) {
 			if (Math.abs(bnd) <= PHYS_TOUCH) {
 				coll.isContact = true;
-				coll.hitNormal = this.normal;
+				coll.hitNormal.set(this.normal);
 				coll.hitOrgNormalVelocity = bnv;           // remember original normal velocity
 				coll.hitDistance = bnd;
 				return 0.0;                                // hit time is ignored for contacts
@@ -80,7 +80,7 @@ export class HitPlane extends HitObject {
 			return -1.0;
 		}
 
-		coll.hitNormal = this.normal;
+		coll.hitNormal.set(this.normal);
 		coll.hitDistance = bnd;                            // actual contact distance
 
 		return hitTime;

--- a/lib/physics/hit-plane.ts
+++ b/lib/physics/hit-plane.ts
@@ -95,7 +95,7 @@ export class HitPlane extends HitObject {
 			// if ball has penetrated, push it out of the plane
 			const v = this.normal.clone(true).multiplyScalar(bnd);
 			coll.ball.state.pos.add(v);
-			v.release();
+			Vertex3D.release(v);
 		}
 	}
 }

--- a/lib/physics/hit-plane.ts
+++ b/lib/physics/hit-plane.ts
@@ -93,7 +93,9 @@ export class HitPlane extends HitObject {
 		const bnd = this.normal.dot(coll.ball.state.pos) - coll.ball.data.radius - this.d;
 		if (bnd < 0) {
 			// if ball has penetrated, push it out of the plane
-			coll.ball.state.pos.add(this.normal.clone().multiplyScalar(bnd));
+			const v = this.normal.clone(true).multiplyScalar(bnd);
+			coll.ball.state.pos.add(v);
+			v.release();
 		}
 	}
 }

--- a/lib/physics/hit-plane.ts
+++ b/lib/physics/hit-plane.ts
@@ -21,7 +21,7 @@ import { Vertex3D } from '../math/vertex3d';
 import { Ball } from '../vpt/ball/ball';
 import { CollisionEvent } from './collision-event';
 import { C_CONTACTVEL, PHYS_TOUCH } from './constants';
-import { HitObject, HitTestResult } from './hit-object';
+import { HitObject } from './hit-object';
 
 export class HitPlane extends HitObject {
 
@@ -38,15 +38,15 @@ export class HitPlane extends HitObject {
 		// plane's not a box (i assume)
 	}
 
-	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent): HitTestResult {
+	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent): number {
 		if (!this.isEnabled) {
-			return { hitTime: -1.0, coll };
+			return -1.0;
 		}
 
 		const bnv = this.normal.dot(ball.hit.vel);         // speed in normal direction
 
 		if (bnv > C_CONTACTVEL) {                          // return if clearly ball is receding from object
-			return { hitTime: -1.0, coll };
+			return -1.0;
 		}
 
 		const bnd = this.normal.dot(ball.state.pos) - ball.data.radius - this.d; // distance from plane to ball surface
@@ -54,7 +54,7 @@ export class HitPlane extends HitObject {
 		//!! solely responsible for ball through playfield?? check other places, too (radius*2??)
 		if (bnd < ball.data.radius * -2.0) {
 			// excessive penetration of plane ... no collision HACK
-			return { hitTime: -1.0, coll };
+			return -1.0;
 		}
 
 		let hitTime: number;
@@ -64,9 +64,9 @@ export class HitPlane extends HitObject {
 				coll.hitNormal = this.normal;
 				coll.hitOrgNormalVelocity = bnv;           // remember original normal velocity
 				coll.hitDistance = bnd;
-				return { hitTime: 0, coll };               // hit time is ignored for contacts
+				return 0.0;                                // hit time is ignored for contacts
 			} else {
-				return { hitTime: -1.0, coll };            // large distance, small velocity -> no hit
+				return -1.0;                               // large distance, small velocity -> no hit
 			}
 		}
 
@@ -77,13 +77,13 @@ export class HitPlane extends HitObject {
 
 		if (!isFinite(hitTime) || hitTime < 0 || hitTime > dTime) {
 			// time is outside this frame ... no collision
-			return { hitTime: -1.0, coll };
+			return -1.0;
 		}
 
 		coll.hitNormal = this.normal;
 		coll.hitDistance = bnd;                            // actual contact distance
 
-		return { hitTime, coll };
+		return hitTime;
 	}
 
 	public collide(coll: CollisionEvent): void {

--- a/lib/physics/hit-point.ts
+++ b/lib/physics/hit-point.ts
@@ -24,7 +24,7 @@ import { Vertex3D } from '../math/vertex3d';
 import { Ball } from '../vpt/ball/ball';
 import { CollisionEvent } from './collision-event';
 import { C_CONTACTVEL, PHYS_TOUCH } from './constants';
-import { HitObject, HitTestResult } from './hit-object';
+import { HitObject } from './hit-object';
 
 export class HitPoint extends HitObject {
 
@@ -39,9 +39,9 @@ export class HitPoint extends HitObject {
 		this.hitBBox = new FRect3D(this.p.x, this.p.x, this.p.y, this.p.y, this.p.z, this.p.z);
 	}
 
-	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent, physics: PlayerPhysics): HitTestResult {
+	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent, physics: PlayerPhysics): number {
 		if (!this.isEnabled) {
-			return { hitTime: -1.0, coll };
+			return -1.0;
 		}
 
 		// relative ball position
@@ -51,7 +51,7 @@ export class HitPoint extends HitObject {
 		const bcdd = Math.sqrt(bcddsq);                    // distance ball to line
 		if (bcdd <= 1.0e-6) {
 			Vertex3D.release(dist);
-			return { hitTime: -1.0, coll };                // no hit on exact center
+			return -1.0;                // no hit on exact center
 		}
 
 		const b = dist.dot(ball.hit.vel);
@@ -59,7 +59,7 @@ export class HitPoint extends HitObject {
 		Vertex3D.release(dist);
 
 		if (bnv > C_CONTACTVEL) {
-			return { hitTime: -1.0, coll };                // clearly receding from radius
+			return -1.0;                // clearly receding from radius
 		}
 
 		const bnd = bcdd - ball.data.radius;               // ball distance to line
@@ -77,12 +77,12 @@ export class HitPoint extends HitObject {
 			}
 		} else {
 			if (a < 1.0e-8) {
-				return { hitTime: -1.0, coll };            // no hit - ball not moving relative to object
+				return -1.0;            // no hit - ball not moving relative to object
 			}
 
 			const sol = solveQuadraticEq(a, 2.0 * b, bcddsq - ball.data.radius * ball.data.radius);
 			if (!sol) {
-				return { hitTime: -1.0, coll };
+				return -1.0;
 			}
 			const time1 = sol[0];
 			const time2 = sol[1];
@@ -92,7 +92,7 @@ export class HitPoint extends HitObject {
 		}
 
 		if (!isFinite(hitTime) || hitTime < 0 || hitTime > dTime) {
-			return { hitTime: -1.0, coll };                // contact out of physics frame
+			return -1.0;                // contact out of physics frame
 		}
 
 		const hitVel = ball.hit.vel.clone(true).multiplyScalar(hitTime);
@@ -111,7 +111,7 @@ export class HitPoint extends HitObject {
 		coll.hitDistance = bnd;                            // actual contact distance
 		//coll.m_hitRigid = true;
 
-		return { hitTime, coll };
+		return hitTime;
 	}
 
 	public collide(coll: CollisionEvent): void {

--- a/lib/physics/hit-point.ts
+++ b/lib/physics/hit-point.ts
@@ -115,8 +115,8 @@ export class HitPoint extends HitObject {
 	}
 
 	public collide(coll: CollisionEvent): void {
-		const dot = coll.hitNormal!.dot(coll.ball.hit.vel);
-		coll.ball.hit.collide3DWall(coll.hitNormal!, this.elasticity, this.elasticityFalloff, this.friction, this.scatter);
+		const dot = coll.hitNormal.dot(coll.ball.hit.vel);
+		coll.ball.hit.collide3DWall(coll.hitNormal, this.elasticity, this.elasticityFalloff, this.friction, this.scatter);
 
 		if (dot <= -this.threshold) {
 			this.fireHitEvent(coll.ball);

--- a/lib/physics/hit-point.ts
+++ b/lib/physics/hit-point.ts
@@ -50,13 +50,13 @@ export class HitPoint extends HitObject {
 		const bcddsq = dist.lengthSq();                    // ball center to line distance squared
 		const bcdd = Math.sqrt(bcddsq);                    // distance ball to line
 		if (bcdd <= 1.0e-6) {
-			dist.release();
+			Vertex3D.release(dist);
 			return { hitTime: -1.0, coll };                // no hit on exact center
 		}
 
 		const b = dist.dot(ball.hit.vel);
 		const bnv = b / bcdd;                              // ball normal velocity
-		dist.release();
+		Vertex3D.release(dist);
 
 		if (bnv > C_CONTACTVEL) {
 			return { hitTime: -1.0, coll };                // clearly receding from radius
@@ -101,8 +101,7 @@ export class HitPoint extends HitObject {
 			.sub(this.p)
 			.normalize();
 		coll.hitNormal.set(hitNormal);
-		hitVel.release();
-		hitNormal.release();
+		Vertex3D.release(hitVel, hitNormal);
 
 		coll.isContact = isContact;
 		if (isContact) {

--- a/lib/physics/hit-quadtree.ts
+++ b/lib/physics/hit-quadtree.ts
@@ -49,38 +49,37 @@ export class HitQuadtree {
 		this.createNextLevel(bounds, 0, 0);
 	}
 
-	public hitTestBall(ball: Ball, coll: CollisionEvent, physics: PlayerPhysics): CollisionEvent {
+	public hitTestBall(ball: Ball, coll: CollisionEvent, physics: PlayerPhysics): void {
 		for (const vho of this.vho) {
 			if (ball.hit !== vho                                              // ball can not hit itself
 				&& vho.hitBBox.intersectRect(ball.hit.hitBBox)
 				&& vho.hitBBox.intersectSphere(ball.state.pos, ball.hit.rcHitRadiusSqr)) {
 
-				coll = vho.doHitTest(ball, coll, physics);
+				vho.doHitTest(ball, coll, physics);
 			}
 		}
 
 		if (!this.isLeaf) {
-			const fLeft = ball.hit.hitBBox.left <= this.vCenter.x;
-			const fRight = ball.hit.hitBBox.right >= this.vCenter.x;
+			const isLeft = ball.hit.hitBBox.left <= this.vCenter.x;
+			const isRight = ball.hit.hitBBox.right >= this.vCenter.x;
 
 			if (ball.hit.hitBBox.top <= this.vCenter.y) { // Top
-				if (fLeft) {
-					coll = this.children[0].hitTestBall(ball, coll, physics);
+				if (isLeft) {
+					this.children[0].hitTestBall(ball, coll, physics);
 				}
-				if (fRight) {
-					coll = this.children[1].hitTestBall(ball, coll, physics);
+				if (isRight) {
+					this.children[1].hitTestBall(ball, coll, physics);
 				}
 			}
 			if (ball.hit.hitBBox.bottom >= this.vCenter.y) { // Bottom
-				if (fLeft) {
-					coll = this.children[2].hitTestBall(ball, coll, physics);
+				if (isLeft) {
+					this.children[2].hitTestBall(ball, coll, physics);
 				}
-				if (fRight) {
-					coll = this.children[3].hitTestBall(ball, coll, physics);
+				if (isRight) {
+					this.children[3].hitTestBall(ball, coll, physics);
 				}
 			}
 		}
-		return coll;
 	}
 
 	// public hitTestXRay(ball: Ball, pvhoHit: HitObject[], coll: CollisionEvent, player: Player): void {

--- a/lib/physics/hit-triangle.ts
+++ b/lib/physics/hit-triangle.ts
@@ -154,7 +154,7 @@ export class HitTriangle extends HitObject {
 
 	public collide(coll: CollisionEvent, physics: PlayerPhysics): void {
 		const ball = coll.ball;
-		const hitNormal = coll.hitNormal!;
+		const hitNormal = coll.hitNormal;
 		const dot = -(hitNormal.dot(ball.hit.vel));
 
 		ball.hit.collide3DWall(this.normal, this.elasticity, this.elasticityFalloff, this.friction, this.scatter);

--- a/lib/physics/hit-triangle.ts
+++ b/lib/physics/hit-triangle.ts
@@ -137,7 +137,7 @@ export class HitTriangle extends HitObject {
 
 		Vertex3D.release(hitPos);
 		if (pointInTriangle) {
-			coll.hitNormal = this.normal;
+			coll.hitNormal.set(this.normal);
 			coll.hitDistance = bnd;                        // 3dhit actual contact distance ...
 			//coll.m_hitRigid = true;                      // collision type
 

--- a/lib/physics/hit-triangle.ts
+++ b/lib/physics/hit-triangle.ts
@@ -40,8 +40,7 @@ export class HitTriangle extends HitObject {
 		const e1 = this.rgv[1].clone(true).sub(this.rgv[0]);
 		this.normal = Vertex3D.crossProduct(e0, e1);
 		this.normal.normalizeSafe();
-		e0.release();
-		e1.release();
+		Vertex3D.release(e0, e1);
 
 		this.elasticity = 0.3;
 		this.setFriction(0.3);
@@ -72,12 +71,11 @@ export class HitTriangle extends HitObject {
 		const hitPos = ball.state.pos.clone(true).sub(normRadius);     // nearest point on ball ... projected radius along norm
 		const hpSubRgv0 = hitPos.clone(true).sub(this.rgv[0]);
 		const bnd = this.normal.dot(hpSubRgv0);                                // distance from plane to ball
-		normRadius.release();
-		hpSubRgv0.release();
+		Vertex3D.release(normRadius, hpSubRgv0);
 
 		if (bnd < -ball.data.radius) {
 			// (ball normal distance) excessive penetration of object skin ... no collision HACK
-			hitPos.release();
+			Vertex3D.release(hitPos);
 			return { hitTime: -1.0, coll };
 		}
 
@@ -100,19 +98,19 @@ export class HitTriangle extends HitObject {
 			hitTime = bnd / -bnv;                          // rate ok for safe divide
 
 		} else {
-			hitPos.release();
+			Vertex3D.release(hitPos);
 			return { hitTime: -1.0, coll };                // wait for touching
 		}
 
 		if (!isFinite(hitTime) || hitTime < 0 || hitTime > dTime) {
-			hitPos.release();
+			Vertex3D.release(hitPos);
 			return { hitTime: -1.0, coll };                // time is outside this frame ... no collision
 		}
 
 		// advance hit point to contact
 		const adv = ball.hit.vel.clone(true).multiplyScalar(hitTime);
 		hitPos.add(adv);
-		adv.release();
+		Vertex3D.release(adv);
 
 		// Check if hitPos is within the triangle
 		// 1. Compute vectors
@@ -127,9 +125,7 @@ export class HitTriangle extends HitObject {
 		const dot11 = v1.dot(v1);
 		const dot12 = v1.dot(v2);
 
-		v0.release();
-		v1.release();
-		v2.release();
+		Vertex3D.release(v0, v1, v2);
 
 		// 3. Compute barycentric coordinates
 		const invDenom = 1.0 / (dot00 * dot11 - dot01 * dot01);
@@ -139,7 +135,7 @@ export class HitTriangle extends HitObject {
 		// 4. Check if point is in triangle
 		const pointInTriangle = (u >= 0) && (v >= 0) && (u + v <= 1);
 
-		hitPos.release();
+		Vertex3D.release(hitPos);
 		if (pointInTriangle) {
 			coll.hitNormal = this.normal;
 			coll.hitDistance = bnd;                        // 3dhit actual contact distance ...

--- a/lib/physics/hit-triangle.ts
+++ b/lib/physics/hit-triangle.ts
@@ -22,7 +22,7 @@ import { Vertex3D } from '../math/vertex3d';
 import { Ball } from '../vpt/ball/ball';
 import { CollisionEvent } from './collision-event';
 import { C_CONTACTVEL, C_LOWNORMVEL, PHYS_TOUCH } from './constants';
-import { HitObject, HitTestResult } from './hit-object';
+import { HitObject } from './hit-object';
 
 export class HitTriangle extends HitObject {
 
@@ -56,14 +56,14 @@ export class HitTriangle extends HitObject {
 		this.hitBBox.zhigh = Math.max(this.rgv[0].z, Math.max(this.rgv[1].z, this.rgv[2].z));
 	}
 
-	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent, physics: PlayerPhysics): HitTestResult {
+	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent, physics: PlayerPhysics): number {
 		if (!this.isEnabled) {
-			return { hitTime: -1.0, coll };
+			return -1.0;
 		}
 
 		const bnv = this.normal.dot(ball.hit.vel);         // speed in Normal-vector direction
 		if (bnv > C_CONTACTVEL) {                          // return if clearly ball is receding from object
-			return { hitTime: -1.0, coll };
+			return -1.0;
 		}
 
 		// Point on the ball that will hit the polygon, if it hits at all
@@ -76,7 +76,7 @@ export class HitTriangle extends HitObject {
 		if (bnd < -ball.data.radius) {
 			// (ball normal distance) excessive penetration of object skin ... no collision HACK
 			Vertex3D.release(hitPos);
-			return { hitTime: -1.0, coll };
+			return -1.0;
 		}
 
 		let isContact = false;
@@ -99,12 +99,12 @@ export class HitTriangle extends HitObject {
 
 		} else {
 			Vertex3D.release(hitPos);
-			return { hitTime: -1.0, coll };                // wait for touching
+			return -1.0;                // wait for touching
 		}
 
 		if (!isFinite(hitTime) || hitTime < 0 || hitTime > dTime) {
 			Vertex3D.release(hitPos);
-			return { hitTime: -1.0, coll };                // time is outside this frame ... no collision
+			return -1.0;                // time is outside this frame ... no collision
 		}
 
 		// advance hit point to contact
@@ -145,10 +145,10 @@ export class HitTriangle extends HitObject {
 				coll.isContact = true;
 				coll.hitOrgNormalVelocity = bnv;
 			}
-			return { hitTime, coll };
+			return hitTime;
 
 		} else {
-			return { hitTime: -1.0, coll };
+			return -1.0;
 		}
 	}
 

--- a/lib/physics/line-seg-slingshot.ts
+++ b/lib/physics/line-seg-slingshot.ts
@@ -25,6 +25,7 @@ import { SurfaceData } from '../vpt/surface/surface-data';
 import { SlingshotAnimObject } from './anim-slingshot';
 import { CollisionEvent } from './collision-event';
 import { LineSeg } from './line-seg';
+import { Vertex3D } from '../math/vertex3d';
 
 export class LineSegSlingshot extends LineSeg {
 
@@ -61,7 +62,7 @@ export class LineSegSlingshot extends LineSeg {
 			// vHitPoint will now be the point where the ball hits the line
 			// Calculate this distance from the center of the slingshot to get force
 			const btd = (vHitPoint.x - this.v1.x) * hitNormal.y - (vHitPoint.y - this.v1.y) * hitNormal.x; // distance to vhit from V1
-			vHitPoint.release();
+			Vertex2D.release(vHitPoint);
 			let force = (Math.abs(len) > 1.0e-6) ? ((btd + btd) / len - 1.0) : -1.0;                       // -1..+1
 			force = 0.5 * (1.0 - force * force);                               // !! maximum value 0.5 ...I think this should have been 1.0...oh well
 			// will match the previous physics
@@ -70,7 +71,7 @@ export class LineSegSlingshot extends LineSeg {
 			// boost velocity, drive into slingshot (counter normal), allow CollideWall to handle the remainder
 			const normForce = hitNormal.clone(true).multiplyScalar(force);
 			ball.hit.vel.sub(normForce);
-			normForce.release();
+			Vertex3D.release(normForce);
 		}
 
 		ball.hit.collide3DWall(hitNormal, this.elasticity, this.elasticityFalloff, this.friction, this.scatter);
@@ -79,7 +80,7 @@ export class LineSegSlingshot extends LineSeg {
 			// is this the same place as last event? if same then ignore it
 			const eventPos = ball.hit.eventPos.clone(true);
 			const distLs = eventPos.sub(ball.state.pos).lengthSq();
-			eventPos.release();
+			Vertex3D.release(eventPos);
 			ball.hit.eventPos.set(ball.state.pos); //remember last collide position
 
 			if (distLs > 0.25) { // must be a new place if only by a little

--- a/lib/physics/line-seg-slingshot.ts
+++ b/lib/physics/line-seg-slingshot.ts
@@ -46,9 +46,9 @@ export class LineSegSlingshot extends LineSeg {
 
 	public collide(coll: CollisionEvent): void {
 		const ball = coll.ball;
-		const hitNormal = coll.hitNormal!;
+		const hitNormal = coll.hitNormal;
 
-		const dot = coll.hitNormal!.dot(coll.ball.hit.vel);                    // normal velocity to slingshot
+		const dot = coll.hitNormal.dot(coll.ball.hit.vel);                    // normal velocity to slingshot
 		const threshold = (dot <= -this.surfaceData.slingshotThreshold);       // normal greater than threshold?
 
 		if (!this.surface.isDisabled && threshold) {                           // enabled and if velocity greater than threshold level

--- a/lib/physics/line-seg-slingshot.ts
+++ b/lib/physics/line-seg-slingshot.ts
@@ -20,12 +20,12 @@
 import { Event } from '../game/event';
 import { PlayerPhysics } from '../game/player-physics';
 import { Vertex2D } from '../math/vertex2d';
+import { Vertex3D } from '../math/vertex3d';
 import { Surface } from '../vpt/surface/surface';
 import { SurfaceData } from '../vpt/surface/surface-data';
 import { SlingshotAnimObject } from './anim-slingshot';
 import { CollisionEvent } from './collision-event';
 import { LineSeg } from './line-seg';
-import { Vertex3D } from '../math/vertex3d';
 
 export class LineSegSlingshot extends LineSeg {
 

--- a/lib/physics/line-seg.ts
+++ b/lib/physics/line-seg.ts
@@ -29,7 +29,7 @@ export class LineSeg extends HitObject {
 
 	public readonly v1: Vertex2D;
 	public readonly v2: Vertex2D;
-	protected normal!: Vertex2D;
+	protected normal: Vertex2D = new Vertex2D();
 	protected length!: number;
 
 	constructor(p1: Vertex2D, p2: Vertex2D, zLow: number, zHigh: number, objType?: CollisionType) {
@@ -164,7 +164,7 @@ export class LineSeg extends HitObject {
 		}
 
 		// hit normal is same as line segment normal
-		coll.hitNormal = new Vertex3D(this.normal.x, this.normal.y, 0.0);
+		coll.hitNormal.set(this.normal.x, this.normal.y, 0.0);
 		coll.hitDistance = bnd;        // actual contact distance ...
 		//coll.m_hitRigid = rigid;     // collision type
 
@@ -186,12 +186,13 @@ export class LineSeg extends HitObject {
 	}
 
 	private calcNormal(): this {
-		const vT = new Vertex2D(this.v1.x - this.v2.x, this.v1.y - this.v2.y);
+		const vT = Vertex2D.claim(this.v1.x - this.v2.x, this.v1.y - this.v2.y);
 
 		// Set up line normal
 		this.length = vT.length();
 		const invLength = 1.0 / this.length;
-		this.normal = new Vertex2D(vT.y * invLength, -vT.x * invLength);
+		this.normal.set(vT.y * invLength, -vT.x * invLength);
+		vT.release();
 		return this;
 	}
 }

--- a/lib/physics/line-seg.ts
+++ b/lib/physics/line-seg.ts
@@ -18,12 +18,11 @@
  */
 
 import { Vertex2D } from '../math/vertex2d';
-import { Vertex3D } from '../math/vertex3d';
 import { Ball } from '../vpt/ball/ball';
 import { CollisionEvent } from './collision-event';
 import { CollisionType } from './collision-type';
 import { C_CONTACTVEL, C_LOWNORMVEL, C_TOL_ENDPNTS, C_TOL_RADIUS, PHYS_TOUCH } from './constants';
-import { HitObject, HitTestResult } from './hit-object';
+import { HitObject } from './hit-object';
 
 export class LineSeg extends HitObject {
 
@@ -65,14 +64,14 @@ export class LineSeg extends HitObject {
 		return this;
 	}
 
-	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent): HitTestResult {
+	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent): number {
 		return this.hitTestBasic(ball, dTime, coll, true, true, true); // normal face, lateral, rigid
 	}
 
-	public hitTestBasic(ball: Ball, dTime: number, coll: CollisionEvent, direction: boolean, lateral: boolean, rigid: boolean): HitTestResult {
+	public hitTestBasic(ball: Ball, dTime: number, coll: CollisionEvent, direction: boolean, lateral: boolean, rigid: boolean): number {
 
 		if (!this.isEnabled || ball.hit.isFrozen) {
-			return { hitTime: -1.0, coll };
+			return -1.0;
 		}
 
 		// ball velocity
@@ -85,7 +84,7 @@ export class LineSeg extends HitObject {
 
 		// direction true and clearly receding from normal face
 		if (direction && bnv > C_LOWNORMVEL) {
-			return { hitTime: -1.0, coll };
+			return -1.0;
 		}
 
 		// ball position
@@ -107,7 +106,7 @@ export class LineSeg extends HitObject {
 		if (rigid) {
 			if (bnd < -ball.data.radius || lateral && bcpd < 0) {
 				// (ball normal distance) excessive penetration of object skin ... no collision HACK
-				return { hitTime: -1.0, coll };
+				return -1.0;
 			}
 			if (lateral && bnd <= PHYS_TOUCH) {
 				if (inside
@@ -123,7 +122,7 @@ export class LineSeg extends HitObject {
 				hitTime = bnd / -bnv;                                // rate ok for safe divide
 
 			} else {
-				return { hitTime: -1.0, coll };                      // wait for touching
+				return -1.0;                      // wait for touching
 			}
 		} else { //non-rigid ... target hits
 			if (bnv * bnd >= 0) {                                                 // outside-receding || inside-approaching
@@ -131,7 +130,7 @@ export class LineSeg extends HitObject {
 					|| !ball.hit.isRealBall()                                     // is a trigger, so test:
 					|| Math.abs(bnd) >= ball.data.radius * 0.5                    // not too close ... nor too far away
 					|| inside !== (ball.hit.vpVolObjs.indexOf(this.obj!) < 0)) {  // ...ball outside and hit set or ball inside and no hit set
-					return { hitTime: -1.0, coll };
+					return -1.0;
 				}
 				hitTime = 0;
 				isUnHit = !inside;                                    // ball on outside is UnHit, otherwise it's a Hit
@@ -141,7 +140,7 @@ export class LineSeg extends HitObject {
 		}
 
 		if (!isFinite(hitTime) || hitTime < 0 || hitTime > dTime) {
-			return { hitTime: -1.0, coll };                          // time is outside this frame ... no collision
+			return -1.0;                          // time is outside this frame ... no collision
 		}
 		const btv = ballVx * this.normal.y - ballVy * this.normal.x; // ball velocity tangent to segment with respect to direction from V1 to V2
 		const btd = (ballX - this.v1.x) * this.normal.y
@@ -149,7 +148,7 @@ export class LineSeg extends HitObject {
 			+ btv * hitTime;                                         // ball tangent distance (projection) (initial position + velocity * hitime)
 
 		if (btd < -C_TOL_ENDPNTS || btd > this.length + C_TOL_ENDPNTS) {  // is the contact off the line segment???
-			return { hitTime: -1.0, coll };
+			return -1.0;
 		}
 		if (!rigid) {                                                // non rigid body collision? return direction
 			coll.hitFlag = isUnHit;                                  // UnHit signal is receding from outside target
@@ -160,7 +159,7 @@ export class LineSeg extends HitObject {
 
 		if (hitZ + ballRadius * 0.5 < this.hitBBox.zlow              // check limits of object's height and depth
 			|| hitZ - ballRadius * 0.5 > this.hitBBox.zhigh) {
-			return { hitTime: -1.0, coll };
+			return -1.0;
 		}
 
 		// hit normal is same as line segment normal
@@ -173,7 +172,7 @@ export class LineSeg extends HitObject {
 			coll.isContact = true;
 			coll.hitOrgNormalVelocity = bnv;
 		}
-		return { hitTime, coll };
+		return hitTime;
 	}
 
 	public collide(coll: CollisionEvent): void {

--- a/lib/physics/line-seg.ts
+++ b/lib/physics/line-seg.ts
@@ -192,7 +192,7 @@ export class LineSeg extends HitObject {
 		this.length = vT.length();
 		const invLength = 1.0 / this.length;
 		this.normal.set(vT.y * invLength, -vT.x * invLength);
-		vT.release();
+		Vertex2D.release(vT);
 		return this;
 	}
 }

--- a/lib/physics/line-seg.ts
+++ b/lib/physics/line-seg.ts
@@ -176,8 +176,8 @@ export class LineSeg extends HitObject {
 	}
 
 	public collide(coll: CollisionEvent): void {
-		const dot = coll.hitNormal!.dot(coll.ball.hit.vel);
-		coll.ball.hit.collide3DWall(coll.hitNormal!, this.elasticity, this.elasticityFalloff, this.friction, this.scatter);
+		const dot = coll.hitNormal.dot(coll.ball.hit.vel);
+		coll.ball.hit.collide3DWall(coll.hitNormal, this.elasticity, this.elasticityFalloff, this.friction, this.scatter);
 
 		if (dot <= -this.threshold) {
 			this.fireHitEvent(coll.ball);

--- a/lib/util/object-pool.ts
+++ b/lib/util/object-pool.ts
@@ -1,0 +1,52 @@
+/*
+ * VPDB - Virtual Pinball Database
+ * Copyright (C) 2019 freezy <freezy@vpdb.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+export class Pool<T> {
+
+	private readonly pool: T[];
+	private readonly poolable: IPoolable<T>;
+
+	constructor(poolable: IPoolable<T>) {
+		this.pool = [];
+		this.poolable = poolable;
+	}
+
+	public get(): T {
+		if (this.pool.length) {
+			return this.pool.splice(0, 1)[0];
+		}
+		return new this.poolable();
+	}
+
+	public release(obj: T): void {
+		if (this.poolable.reset) {
+			this.poolable.reset(obj);
+		}
+		this.pool.push(obj);
+	}
+}
+
+export interface IPoolable<T> {
+
+	// constructor
+	new(): T;
+
+	// static
+	reset?(obj: T): void;
+}

--- a/lib/util/object-pool.ts
+++ b/lib/util/object-pool.ts
@@ -21,30 +21,77 @@ import { logger } from './logger';
 
 export class Pool<T> {
 
+	private static DEBUG = 0; // globally enable debug prints
 	private static MAX_POOL_SIZE = 100;
 	private readonly pool: T[];
 	private readonly poolable: IPoolable<T>;
 	private warned = false;
 
+	private debugging?: any;
+	private recycled = 0;
+	private created = 0;
+	private released = 0;
+	private skipped = 0;
+	private claimed: { [key: string]: number } = {};
+	private unclaimed: { [key: string]: number } = {};
+
 	constructor(poolable: IPoolable<T>) {
 		this.pool = [];
 		this.poolable = poolable;
+		if (Pool.DEBUG > 0) {
+			this.setupDebug(Pool.DEBUG);
+		}
 	}
 
 	public get(): T {
-		if (this.pool.length) {
-			return this.pool.splice(0, 1)[0];
+		let caller = '';
+		let obj: any;
+		if (this.debugging) {
+			caller = (new Error()).stack!.split('\n')[3].trim();
+			if (!this.claimed[caller]) {
+				this.claimed[caller] = 0;
+			}
+			this.claimed[caller]++;
 		}
-		if (this.pool.length < Pool.MAX_POOL_SIZE) {
-			this.warned = false;
+
+		if (this.pool.length) {                                      // something left in pool?
+			this.recycled++;
+			obj = this.pool.splice(0, 1)[0];
+
+		} else {                                                     // if not, instantiate.
+			if (this.pool.length < Pool.MAX_POOL_SIZE) {
+				this.warned = false;
+			}
+			this.created++;
+			obj = new this.poolable() as any;
 		}
-		const obj = new this.poolable();
-		(obj as any).__pool = true;
+
+		if (caller) {                                                // update meta props
+			obj.__caller = caller;
+		} else {
+			delete obj._caller;
+		}
+		obj.__pool = true;
 		return obj;
 	}
 
 	public release(obj: T): void {
+		if ((obj as any).__caller) {
+			const caller = (obj as any).__caller;
+			if (!this.claimed[caller]) {
+				if (!this.unclaimed[caller]) {
+					this.unclaimed[caller] = 0;
+				}
+				this.unclaimed[caller]++;
+			} else {
+				this.claimed[caller]--;
+				if (this.claimed[caller] === 0) {
+					delete this.claimed[caller];
+				}
+			}
+		}
 		if (!(obj as any).__pool) {
+			this.skipped++;
 			logger().warn('Trying to recycle non-claimed %s, aborting.', this.poolable.name);
 			return;
 		}
@@ -53,12 +100,44 @@ export class Pool<T> {
 				logger().warn('Pool size %s of %s is exhausted, future objects will be garbage-collected.', Pool.MAX_POOL_SIZE, this.poolable.name);
 				this.warned = true;
 			}
+			this.skipped++;
 			return;
 		}
 		if (this.poolable.reset) {
 			this.poolable.reset(obj);
 		}
+		this.released++;
 		this.pool.push(obj);
+	}
+
+	public enableDebug(interval = 10000): this {
+		if (Pool.DEBUG <= 0 && interval > 0) {
+			logger().debug('[Pool] %s: Debug enabled.', this.poolable.name);
+			this.setupDebug(interval);
+		}
+		return this;
+	}
+
+	private setupDebug(interval: number) {
+		this.debugging = setInterval(() => {
+			logger().debug('[Pool] %s: %s recycled, %s created, %s released, %s skipped (%s%)',
+				this.poolable.name, this.recycled, this.created, this.released, this.skipped,
+				Math.floor(this.recycled / (this.recycled + this.created) * 100000) / 1000);
+
+			for (const caller of Object.keys(this.claimed)) {
+				logger().debug('[Pool] %s: Unreleased: %d %s', this.poolable.name, this.claimed[caller], caller);
+			}
+			for (const caller of Object.keys(this.unclaimed)) {
+				logger().debug('[Pool] %s: Released without claimed: %d %s', this.poolable.name, this.unclaimed[caller], caller);
+			}
+
+			this.recycled = 0;
+			this.created = 0;
+			this.released = 0;
+			this.skipped = 0;
+			this.claimed = {};
+			this.unclaimed = {};
+		}, interval);
 	}
 }
 

--- a/lib/util/object-pool.ts
+++ b/lib/util/object-pool.ts
@@ -17,13 +17,19 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { Matrix4 } from 'three';
 import { logger } from './logger';
 
 export class Pool<T> {
 
+	public static GENERIC = {
+		Matrix4: new Pool<Matrix4>(Matrix4),
+	};
+
 	private static DEBUG = 0; // globally enable debug prints
 	private static TRACE = false;
 	private static MAX_POOL_SIZE = 100;
+
 	private readonly pool: T[];
 	private readonly poolable: IPoolable<T>;
 	private warned = false;

--- a/lib/vpt/ball/ball-hit.ts
+++ b/lib/vpt/ball/ball-hit.ts
@@ -33,7 +33,7 @@ import {
 	C_PRECISION,
 	PHYS_TOUCH,
 } from '../../physics/constants';
-import { elasticityWithFalloff, hardScatter } from '../../physics/functions';
+import { elasticityWithFalloff, HARD_SCATTER } from '../../physics/functions';
 import { HitObject } from '../../physics/hit-object';
 import { FLT_MIN } from '../mesh';
 import { TableData } from '../table/table-data';
@@ -381,7 +381,7 @@ export class BallHit extends HitObject {
 		Vertex3D.release(surfP, surfVel, tangent);
 
 		if (scatterAngle < 0.0) {
-			scatterAngle = hardScatter;
+			scatterAngle = HARD_SCATTER;
 		}  // if < 0 use global value
 		scatterAngle *= this.tableData.globalDifficulty!; // apply difficulty weighting
 

--- a/lib/vpt/ball/ball-hit.ts
+++ b/lib/vpt/ball/ball-hit.ts
@@ -41,7 +41,6 @@ import { Ball } from './ball';
 import { BallData } from './ball-data';
 import { BallMover } from './ball-mover';
 import { BallState } from './ball-state';
-import { Vector2 } from 'three';
 
 /**
  * In the VP source code this is all part of ball.cpp. We'll try
@@ -50,7 +49,7 @@ import { Vector2 } from 'three';
 export class BallHit extends HitObject {
 
 	public isFrozen: boolean;
-	public coll: CollisionEvent;
+	public readonly coll: CollisionEvent;
 	public rcHitRadiusSqr: number = 0;
 	public vpVolObjs: EventProxy[] = [];
 

--- a/lib/vpt/ball/ball-hit.ts
+++ b/lib/vpt/ball/ball-hit.ts
@@ -466,7 +466,8 @@ export class BallHit extends HitObject {
 
 			const surfAcc = this.surfaceAcceleration(surfP, physics, true);
 			// calc the tangential slip acceleration
-			const slipAcc = surfAcc.clone(true).subAndRelease(hitNormal.clone(true).multiplyScalar(surfAcc.dot(hitNormal)));
+			const slipAcc = surfAcc.clone(true)
+				.subAndRelease(hitNormal.clone(true).multiplyScalar(surfAcc.dot(hitNormal)));
 
 			// neither slip velocity nor slip acceleration? nothing to do here
 			if (slipAcc.lengthSq() < 1e-6) {
@@ -476,8 +477,7 @@ export class BallHit extends HitObject {
 
 			slipDir = slipAcc.clone(true).normalize();
 			numer = -slipDir.dot(surfAcc);
-
-			Vertex3D.release(surfAcc);
+			Vertex3D.release(surfAcc, slipAcc);
 
 		} else {
 			// nonzero slip speed - dynamic friction case

--- a/lib/vpt/ball/ball-hit.ts
+++ b/lib/vpt/ball/ball-hit.ts
@@ -142,8 +142,8 @@ export class BallHit extends HitObject {
 	}
 
 	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent): number {
-		const d = this.state.pos.clone().sub(ball.state.pos!);  // delta position
-		const dv = this.vel.clone().sub(ball.hit.vel);           // delta velocity
+		const d = this.state.pos.clone(true).sub(ball.state.pos);  // delta position
+		const dv = this.vel.clone(true).sub(ball.hit.vel);           // delta velocity
 
 		let bcddSq = d.lengthSq();            // square of ball center's delta distance
 		let bcdd = Math.sqrt(bcddSq);         // length of delta
@@ -160,8 +160,10 @@ export class BallHit extends HitObject {
 
 		const b = dv.dot(d);                               // inner product
 		const bnv = b / bcdd;                              // normal speed of balls toward each other
+		Vertex3D.release(d);
 
 		if (bnv > C_LOWNORMVEL) {                          // dot of delta velocity and delta displacement, positive if receding no collison
+			Vertex3D.release(dv);
 			return -1.0;
 		}
 
@@ -174,6 +176,7 @@ export class BallHit extends HitObject {
 //#endif
 		if (bnd <= PHYS_TOUCH) {                           // in contact?
 			if (bnd < ball.data.radius * -2.0) {
+				Vertex3D.release(dv);
 				return -1.0;            // embedded too deep?
 			}
 
@@ -192,11 +195,13 @@ export class BallHit extends HitObject {
 		} else {
 			const a = dv.lengthSq();                       // square of differential velocity
 			if (a < 1.0e-8) {
+				Vertex3D.release(dv);
 				return -1.0;            // ball moving really slow, then wait for contact
 			}
 
 			const sol = solveQuadraticEq(a, 2.0 * b, bcddSq - totalRadius * totalRadius);
 			if (!sol) {
+				Vertex3D.release(dv);
 				return -1.0;
 			}
 			const [time1, time2] = sol;
@@ -204,18 +209,22 @@ export class BallHit extends HitObject {
 		}
 
 		if (!isFinite(hitTime) || hitTime < 0 || hitTime > dTime) {
+			Vertex3D.release(dv);
 			return -1.0;                // .. was some time previous || beyond the next physics tick
 		}
 
-		const hitPos = ball.state.pos.clone().add(dv.clone().multiplyScalar(hitTime)); // new ball position
+		const hitPos = ball.state.pos.clone(true).add(dv.multiplyScalar(hitTime)); // new ball position
+		Vertex3D.release(dv);
 
 		// calc unit normal of collision
-		const hitNormal = hitPos.clone().sub(this.state.pos);
+		const hitNormal = hitPos.clone(true).sub(this.state.pos);
+		Vertex3D.release(hitPos);
 		if (Math.abs(hitNormal.x) <= FLT_MIN && Math.abs(hitNormal.y) <= FLT_MIN && Math.abs(hitNormal.z) <= FLT_MIN) {
+			Vertex3D.release(hitNormal);
 			return -1.0;
 		}
-		coll.hitNormal = hitNormal;
-		coll.hitNormal.normalize();
+		coll.hitNormal.set(hitNormal).normalize();
+		Vertex3D.release(hitNormal);
 
 		coll.hitDistance = bnd;                            // actual contact distance
 

--- a/lib/vpt/ball/ball-hit.ts
+++ b/lib/vpt/ball/ball-hit.ts
@@ -422,14 +422,14 @@ export class BallHit extends HitObject {
 		Vertex3D.release(rotI, impulse, angularMomentum);
 	}
 
-	public handleStaticContact(coll: CollisionEvent, friction: number, dtime: number, physics: PlayerPhysics): void {
+	public handleStaticContact(coll: CollisionEvent, friction: number, dTime: number, physics: PlayerPhysics): void {
 		const normVel = this.vel.dot(coll.hitNormal);      // this should be zero, but only up to +/- C_CONTACTVEL
 
 		// If some collision has changed the ball's velocity, we may not have to do anything.
 		if (normVel <= C_CONTACTVEL) {
 			const fe = physics.gravity.clone(true).multiplyScalar(this.data.mass);   // external forces (only gravity for now)
 			const dot = fe.dot(coll.hitNormal);
-			const normalForce = Math.max(0.0, -(dot * dtime + coll.hitOrgNormalVelocity!)); // normal force is always nonnegative
+			const normalForce = Math.max(0.0, -(dot * dTime + coll.hitOrgNormalVelocity!)); // normal force is always nonnegative
 			Vertex3D.release(fe);
 
 			// Add just enough to kill original normal velocity and counteract the external forces.
@@ -441,7 +441,7 @@ export class BallHit extends HitObject {
 			}
 			// #endif
 
-			this.applyFriction(coll.hitNormal, dtime, friction, physics);
+			this.applyFriction(coll.hitNormal, dTime, friction, physics);
 		}
 	}
 

--- a/lib/vpt/ball/ball-hit.ts
+++ b/lib/vpt/ball/ball-hit.ts
@@ -503,7 +503,7 @@ export class BallHit extends HitObject {
 		const p2 = Vertex3D.crossProduct(this.angularVelocity, surfP);
 		const acceleration = physics.gravity
 			.clone(true)
-			.multiplyScalar(this.invMass)                                                                          // linear acceleration
+			.multiplyScalar(this.invMass)                                                 // linear acceleration
 			.addAndRelease(Vertex3D.crossProduct(this.angularVelocity, p2, true)); // centripetal acceleration
 		Vertex3D.release(p2);
 		return acceleration;

--- a/lib/vpt/ball/ball-hit.ts
+++ b/lib/vpt/ball/ball-hit.ts
@@ -499,7 +499,7 @@ export class BallHit extends HitObject {
 
 	public surfaceAcceleration(surfP: Vertex3D, physics: PlayerPhysics): Vertex3D {
 		// if we had any external torque, we would have to add "(deriv. of ang.vel.) x surfP" here
-		const p2 = Vertex3D.crossProduct(this.angularVelocity, surfP);
+		const p2 = Vertex3D.crossProduct(this.angularVelocity, surfP, true);
 		const acceleration = physics.gravity
 			.clone(true)
 			.multiplyScalar(this.invMass)                                                 // linear acceleration

--- a/lib/vpt/ball/ball-state.ts
+++ b/lib/vpt/ball/ball-state.ts
@@ -19,6 +19,7 @@
 
 import { Matrix2D } from '../../math/matrix2d';
 import { Vertex3D } from '../../math/vertex3d';
+import { Pool } from '../../util/object-pool';
 import { ItemState } from '../item-state';
 
 /**
@@ -28,17 +29,30 @@ import { ItemState } from '../item-state';
  */
 export class BallState extends ItemState {
 
-	public readonly pos: Vertex3D;
+	public static readonly POOL = new Pool(BallState);
+
+	public readonly pos: Vertex3D = new Vertex3D();
 	public readonly orientation = new Matrix2D();
 
-	constructor(name: string, pos: Vertex3D, orientation: Matrix2D) {
-		super(name);
-		this.pos = pos;
-		this.orientation = orientation;
+	public constructor() {
+		super();
 	}
 
-	public clone(): ItemState {
-		return new BallState(this.name, this.pos.clone(), this.orientation.clone());
+	public static claim(name: string, pos: Vertex3D): BallState {
+		const state = BallState.POOL.get();
+		state.name = name;
+		state.pos.set(pos);
+		return state;
+	}
+
+	public clone(): BallState {
+		const state = BallState.claim(this.name, this.pos);
+		state.orientation.set(this.orientation);
+		return state;
+	}
+
+	public release(): void {
+		BallState.POOL.release(this);
 	}
 
 	public equals(state: BallState): boolean {

--- a/lib/vpt/ball/ball.ts
+++ b/lib/vpt/ball/ball.ts
@@ -68,21 +68,21 @@ export class Ball implements IPlayable, IMovable<BallState>, IRenderable {
 
 	public applyState(obj: Object3D, table: Table, player: Player): void {
 		const zHeight = !this.hit.isFrozen ? this.state.pos.z : this.state.pos.z - this.data.radius;
-		const orientation = new Matrix3D().set([
+		const orientation = Matrix3D.claim().set([
 			[this.state.orientation.matrix[0][0], this.state.orientation.matrix[1][0], this.state.orientation.matrix[2][0], 0.0],
 			[this.state.orientation.matrix[0][1], this.state.orientation.matrix[1][1], this.state.orientation.matrix[2][1], 0.0],
 			[this.state.orientation.matrix[0][2], this.state.orientation.matrix[1][2], this.state.orientation.matrix[2][2], 0.0],
 			[0, 0, 0, 1],
 		]);
-		const trans = new Matrix3D().setTranslation(this.state.pos.x, this.state.pos.y, zHeight);
-		const matrix = new Matrix3D()
+		const trans = Matrix3D.claim().setTranslation(this.state.pos.x, this.state.pos.y, zHeight);
+		const matrix = Matrix3D.claim()
 			.setScaling(this.data.radius, this.data.radius, this.data.radius)
 			.preMultiply(orientation)
-			.multiply(trans);
+			.multiply(trans)
+			.toRightHanded();
 
-		obj.matrix = new Matrix4();
-		obj.applyMatrix(matrix.toRightHanded().toThreeMatrix4());
-		obj.matrixWorldNeedsUpdate = true;
+		matrix.applyToObject3D(obj);
+		Matrix3D.release(orientation, trans, matrix);
 	}
 
 	public async addToScene(scene: Scene, table: Table): Promise<Group> {

--- a/lib/vpt/ball/ball.ts
+++ b/lib/vpt/ball/ball.ts
@@ -17,14 +17,13 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { Group, Matrix4, Object3D, Scene } from 'three';
+import { Group, Object3D, Scene } from 'three';
 import { IMovable } from '../../game/imovable';
 import { IPlayable } from '../../game/iplayable';
 import { IRenderable } from '../../game/irenderable';
 import { Player } from '../../game/player';
 import { Matrix3D } from '../../math/matrix3d';
 import { Vertex3D } from '../../math/vertex3d';
-import { CollisionEvent } from '../../physics/collision-event';
 import { HitObject } from '../../physics/hit-object';
 import { Meshes } from '../item-data';
 import { Table } from '../table/table';

--- a/lib/vpt/ball/ball.ts
+++ b/lib/vpt/ball/ball.ts
@@ -68,12 +68,12 @@ export class Ball implements IPlayable, IMovable<BallState>, IRenderable {
 
 	public applyState(obj: Object3D, table: Table, player: Player): void {
 		const zHeight = !this.hit.isFrozen ? this.state.pos.z : this.state.pos.z - this.data.radius;
-		const orientation = Matrix3D.claim().set([
-			[this.state.orientation.matrix[0][0], this.state.orientation.matrix[1][0], this.state.orientation.matrix[2][0], 0.0],
-			[this.state.orientation.matrix[0][1], this.state.orientation.matrix[1][1], this.state.orientation.matrix[2][1], 0.0],
-			[this.state.orientation.matrix[0][2], this.state.orientation.matrix[1][2], this.state.orientation.matrix[2][2], 0.0],
-			[0, 0, 0, 1],
-		]);
+		const orientation = Matrix3D.claim().setEach(
+			this.state.orientation.matrix[0][0], this.state.orientation.matrix[1][0], this.state.orientation.matrix[2][0], 0.0,
+			this.state.orientation.matrix[0][1], this.state.orientation.matrix[1][1], this.state.orientation.matrix[2][1], 0.0,
+			this.state.orientation.matrix[0][2], this.state.orientation.matrix[1][2], this.state.orientation.matrix[2][2], 0.0,
+			0, 0, 0, 1,
+		);
 		const trans = Matrix3D.claim().setTranslation(this.state.pos.x, this.state.pos.y, zHeight);
 		const matrix = Matrix3D.claim()
 			.setScaling(this.data.radius, this.data.radius, this.data.radius)

--- a/lib/vpt/ball/ball.ts
+++ b/lib/vpt/ball/ball.ts
@@ -125,7 +125,7 @@ export class Ball implements IPlayable, IMovable<BallState>, IRenderable {
 	}
 
 	public getMeshes(table: Table, opts: VpTableExporterOptions): Meshes {
-		return { ball: { mesh: this.meshGenerator.getMesh().transform(new Matrix3D().toRightHanded()) } };
+		return { ball: { mesh: this.meshGenerator.getMesh().transform(Matrix3D.RIGHT_HANDED) } };
 	}
 
 	/* istanbul ignore next: balls have their own visibility treatment */

--- a/lib/vpt/ball/ball.ts
+++ b/lib/vpt/ball/ball.ts
@@ -46,6 +46,9 @@ export class Ball implements IPlayable, IMovable<BallState>, IRenderable {
 	// unique ID for each ball
 	public readonly id: number;
 
+	// public props
+	get coll() { return this.hit.coll; }
+
 	public static idCounter = 0;
 
 	// ugly hacks
@@ -104,14 +107,6 @@ export class Ball implements IPlayable, IMovable<BallState>, IRenderable {
 
 	public getMover(): BallMover {
 		return this.hit.getMoverObject();
-	}
-
-	public getCollision(): CollisionEvent {
-		return this.hit.coll;
-	}
-
-	public setCollision(coll: CollisionEvent) {
-		return this.hit.coll = coll;
 	}
 
 	/* istanbul ignore next: never called since there is no ball at player setup */

--- a/lib/vpt/bumper/bumper-hit.spec.ts
+++ b/lib/vpt/bumper/bumper-hit.spec.ts
@@ -97,14 +97,14 @@ describe('The VPinball bumper collision', () => {
 
 		player.updatePhysics(710);
 		let states = player.popStates();
-		let state = states.Bumper2 as ChangedState<BumperState>;
+		let state = states.getState<BumperState>('Bumper2');
 		bumper.applyState(bumperObj, table, player, state.oldState as BumperState);
 		ringObj.getWorldPosition(ringPos);
 		expect(ringPos.z).to.equal(16);
 
 		player.updatePhysics(770);
 		states = player.popStates();
-		state = states.Bumper2 as ChangedState<BumperState>;
+		state = states.getState<BumperState>('Bumper2');
 		bumper.applyState(bumperObj, table, player, state.oldState as BumperState);
 		ringObj.getWorldPosition(ringPos);
 		expect(ringPos.z).to.equal(61);

--- a/lib/vpt/bumper/bumper-hit.spec.ts
+++ b/lib/vpt/bumper/bumper-hit.spec.ts
@@ -23,7 +23,7 @@ import sinonChai = require('sinon-chai');
 import { Mesh, Vector3 } from 'three';
 import { createBall } from '../../../test/physics.helper';
 import { ThreeHelper } from '../../../test/three.helper';
-import { ChangedState, Player } from '../../game/player';
+import { Player } from '../../game/player';
 import { NodeBinaryReader } from '../../io/binary-reader.node';
 import { Table } from '../table/table';
 import { BumperState } from './bumper-state';

--- a/lib/vpt/bumper/bumper-hit.ts
+++ b/lib/vpt/bumper/bumper-hit.ts
@@ -50,15 +50,15 @@ export class BumperHit extends HitCircle {
 		}
 
 		// needs to be computed before Collide3DWall()
-		const dot = coll.hitNormal!.dot(coll.ball.hit.vel);
+		const dot = coll.hitNormal.dot(coll.ball.hit.vel);
 
 		// reflect ball from wall
-		coll.ball.hit.collide3DWall(coll.hitNormal!, this.elasticity, this.elasticityFalloff, this.friction, this.scatter);
+		coll.ball.hit.collide3DWall(coll.hitNormal, this.elasticity, this.elasticityFalloff, this.friction, this.scatter);
 
 		// if velocity greater than threshold level
 		if (this.data.hitEvent && (dot <= -this.data.threshold)) {
 			// add a chunk of velocity to drive ball away
-			coll.ball.hit.vel.add(coll.hitNormal!.clone().multiplyScalar(this.data.force));
+			coll.ball.hit.vel.add(coll.hitNormal.clone().multiplyScalar(this.data.force));
 
 			this.animation.hitEvent = true;
 			this.animation.ballHitPosition = coll.ball.state.pos.clone();

--- a/lib/vpt/bumper/bumper-hit.ts
+++ b/lib/vpt/bumper/bumper-hit.ts
@@ -58,10 +58,10 @@ export class BumperHit extends HitCircle {
 		// if velocity greater than threshold level
 		if (this.data.hitEvent && (dot <= -this.data.threshold)) {
 			// add a chunk of velocity to drive ball away
-			coll.ball.hit.vel.add(coll.hitNormal.clone().multiplyScalar(this.data.force));
+			coll.ball.hit.vel.addAndRelease(coll.hitNormal.clone(true).multiplyScalar(this.data.force));
 
 			this.animation.hitEvent = true;
-			this.animation.ballHitPosition = coll.ball.state.pos.clone();
+			this.animation.ballHitPosition.setAndRelease(coll.ball.state.pos.clone(true));
 			this.events.fireGroupEvent(Event.HitEventsHit);
 		}
 	}

--- a/lib/vpt/bumper/bumper-mesh-generator.ts
+++ b/lib/vpt/bumper/bumper-mesh-generator.ts
@@ -91,17 +91,17 @@ export class BumperMeshGenerator {
 	private generateMesh(name: string, mesh: Mesh, matrix: Matrix3D, zPos: (z: number) => number): Mesh {
 		const generatedMesh = mesh.clone(name);
 		for (const vertex of generatedMesh.vertices) {
-			let vert = new Vertex3D(vertex.x, vertex.y, vertex.z);
-			vert = matrix.multiplyVector(vert);
+			const vert = Vertex3D.claim(vertex.x, vertex.y, vertex.z).multiplyMatrix(matrix);
 			vertex.x = vert.x + this.data.vCenter.x;
 			vertex.y = vert.y + this.data.vCenter.y;
 			vertex.z = zPos(vert.z);
 
-			let normal = new Vertex3D(vertex.nx, vertex.ny, vertex.nz);
-			normal = matrix.multiplyVectorNoTranslate(normal);
+			const normal = Vertex3D.claim(vertex.nx, vertex.ny, vertex.nz).multiplyMatrixNoTranslate(matrix);
 			vertex.nx = normal.x;
 			vertex.ny = normal.y;
 			vertex.nz = normal.z;
+
+			Vertex3D.release(vert, normal);
 		}
 		return generatedMesh;
 	}

--- a/lib/vpt/bumper/bumper-mesh-updater.ts
+++ b/lib/vpt/bumper/bumper-mesh-updater.ts
@@ -17,7 +17,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { Matrix4, Object3D } from 'three';
+import { Object3D } from 'three';
 import { Player } from '../../game/player';
 import { degToRad } from '../../math/float';
 import { Matrix3D } from '../../math/matrix3d';

--- a/lib/vpt/bumper/bumper-mesh-updater.ts
+++ b/lib/vpt/bumper/bumper-mesh-updater.ts
@@ -51,26 +51,26 @@ export class BumperMeshUpdater {
 	private applyRingState(obj: Object3D) {
 		const ringObj = obj.children.find(o => o.name === `bumper-ring-${this.data.getName()}`) as Object3D;
 		if (ringObj) {
-			const matrix = new Matrix3D().setTranslation(0, 0, -this.state.ringOffset);
-			ringObj.matrix = new Matrix4();
-			ringObj.applyMatrix(matrix.toThreeMatrix4());
+			const matrix = Matrix3D.claim().setTranslation(0, 0, -this.state.ringOffset);
+			matrix.applyToObject3D(ringObj);
+			Matrix3D.release(matrix);
 		}
 	}
 
 	/* istanbul ignore next: this looks weird. test when sure it's the correct "animation" */
 	private applySkirtState(obj: Object3D, table: Table) {
-		const height = table.getSurfaceHeight(this.data.szSurface, this.data.vCenter.x, this.data.vCenter.y) * table.getScaleZ();
-		const matToOrigin = new Matrix3D().setTranslation(-this.data.vCenter.x, -this.data.vCenter.y, -height);
-		const matFromOrigin = new Matrix3D().setTranslation(this.data.vCenter.x, this.data.vCenter.y, height);
-		const matRotX = new Matrix3D().rotateXMatrix(degToRad(this.state.skirtRotX));
-		const matRotY = new Matrix3D().rotateYMatrix(degToRad(this.state.skirtRotY));
-
-		const matrix = matToOrigin.multiply(matRotY).multiply(matRotX).multiply(matFromOrigin);
-
 		const skirtObj = obj.children.find(o => o.name === `bumper-socket-${this.data.getName()}`) as any;
 		if (skirtObj) {
-			skirtObj.matrix = new Matrix4();
-			skirtObj.applyMatrix(matrix.toThreeMatrix4());
+			const height = table.getSurfaceHeight(this.data.szSurface, this.data.vCenter.x, this.data.vCenter.y) * table.getScaleZ();
+			const matToOrigin = Matrix3D.claim().setTranslation(-this.data.vCenter.x, -this.data.vCenter.y, -height);
+			const matFromOrigin = Matrix3D.claim().setTranslation(this.data.vCenter.x, this.data.vCenter.y, height);
+			const matRotX = Matrix3D.claim().rotateXMatrix(degToRad(this.state.skirtRotX));
+			const matRotY = Matrix3D.claim().rotateYMatrix(degToRad(this.state.skirtRotY));
+
+			const matrix = matToOrigin.multiply(matRotY).multiply(matRotX).multiply(matFromOrigin);
+
+			matrix.applyToObject3D(skirtObj);
+			Matrix3D.release(matToOrigin, matFromOrigin, matRotX, matRotY);
 		}
 	}
 }

--- a/lib/vpt/bumper/bumper-state.ts
+++ b/lib/vpt/bumper/bumper-state.ts
@@ -17,23 +17,40 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { Pool } from '../../util/object-pool';
 import { ItemState } from '../item-state';
 
 export class BumperState extends ItemState {
 
+	public static readonly POOL = new Pool(BumperState);
+
 	/**
 	 * Z-offset of the bumper ring
 	 */
-	public ringOffset: number;
+	public ringOffset: number = 0;
 
-	public skirtRotX: number;
-	public skirtRotY: number;
+	public skirtRotX: number = 0;
+	public skirtRotY: number = 0;
 
-	constructor(name: string, ringOffset: number, skirtRotX: number, skirtRotY: number) {
-		super(name);
-		this.ringOffset = ringOffset;
-		this.skirtRotX = skirtRotX;
-		this.skirtRotY = skirtRotY;
+	public constructor() {
+		super();
+	}
+
+	public static claim(name: string, ringOffset: number, skirtRotX: number, skirtRotY: number): BumperState {
+		const state = BumperState.POOL.get();
+		state.name = name;
+		state.ringOffset = ringOffset;
+		state.skirtRotX = skirtRotX;
+		state.skirtRotY = skirtRotY;
+		return state;
+	}
+
+	public clone(): BumperState {
+		return BumperState.claim(this.name, this.ringOffset, this.skirtRotX, this.skirtRotY);
+	}
+
+	public release(): void {
+		BumperState.POOL.release(this);
 	}
 
 	public equals(state: BumperState): boolean {
@@ -44,9 +61,5 @@ export class BumperState extends ItemState {
 		return state.ringOffset === this.ringOffset
 			&& state.skirtRotX === this.skirtRotX
 			&& state.skirtRotY === this.skirtRotY;
-	}
-
-	public clone(): BumperState {
-		return new BumperState(this.name, this.ringOffset, this.skirtRotX, this.skirtRotY);
 	}
 }

--- a/lib/vpt/bumper/bumper.ts
+++ b/lib/vpt/bumper/bumper.ts
@@ -106,28 +106,28 @@ export class Bumper implements IRenderable, IHittable, IAnimatable<BumperState> 
 		const bumper = this.meshGenerator.getMeshes(table);
 		if (bumper.base) {
 			meshes.base = {
-				mesh: bumper.base.transform(new Matrix3D().toRightHanded()),
+				mesh: bumper.base.transform(Matrix3D.RIGHT_HANDED),
 				material: table.getMaterial(this.data.szBaseMaterial),
 				map: Texture.fromFilesystem('bumperbase.bmp'),
 			};
 		}
 		if (bumper.ring) {
 			meshes.ring = {
-				mesh: bumper.ring.transform(new Matrix3D().toRightHanded()),
+				mesh: bumper.ring.transform(Matrix3D.RIGHT_HANDED),
 				material: table.getMaterial(this.data.szRingMaterial),
 				map: Texture.fromFilesystem('bumperring.bmp'),
 			};
 		}
 		if (bumper.skirt) {
 			meshes.skirt = {
-				mesh: bumper.skirt.transform(new Matrix3D().toRightHanded()),
+				mesh: bumper.skirt.transform(Matrix3D.RIGHT_HANDED),
 				material: table.getMaterial(this.data.szSkirtMaterial),
 				map: Texture.fromFilesystem('bumperskirt.bmp'),
 			};
 		}
 		if (bumper.cap) {
 			meshes.cap = {
-				mesh: bumper.cap.transform(new Matrix3D().toRightHanded()),
+				mesh: bumper.cap.transform(Matrix3D.RIGHT_HANDED),
 				material: table.getMaterial(this.data.szCapMaterial),
 				map: Texture.fromFilesystem('bumperCap.bmp'),
 			};

--- a/lib/vpt/bumper/bumper.ts
+++ b/lib/vpt/bumper/bumper.ts
@@ -57,7 +57,7 @@ export class Bumper implements IRenderable, IHittable, IAnimatable<BumperState> 
 
 	private constructor(data: BumperData) {
 		this.data = data;
-		this.state = new BumperState(this.getName(), 0, 0, 0);
+		this.state = BumperState.claim(this.getName(), 0, 0, 0);
 		this.meshGenerator = new BumperMeshGenerator(data);
 		this.meshUpdater = new BumperMeshUpdater(this.data, this.state, this.meshGenerator);
 	}

--- a/lib/vpt/flipper/flipper-hit.ts
+++ b/lib/vpt/flipper/flipper-hit.ts
@@ -166,7 +166,7 @@ export class FlipperHit extends HitObject {
 		if (normVel <= C_CONTACTVEL) {
 
 			// compute accelerations of point on ball and flipper
-			const aB = ball.hit.surfaceAcceleration(rB, physics);
+			const aB = ball.hit.surfaceAcceleration(rB, physics, true);
 			const aF = this.mover.surfaceAcceleration(rF, true);
 			const aRel = aB.clone(true).sub(aF);
 
@@ -175,7 +175,7 @@ export class FlipperHit extends HitObject {
 
 			// relative acceleration in the normal direction
 			const normAcc = aRel.dot(normal) + 2.0 * normalDeriv.dot(vRel);
-			Vertex3D.release(normalDeriv, aF);
+			Vertex3D.release(normalDeriv, aF, aB);
 
 			if (normAcc >= 0) {
 				Vertex3D.release(aRel, vRel, rB, rF);

--- a/lib/vpt/flipper/flipper-hit.ts
+++ b/lib/vpt/flipper/flipper-hit.ts
@@ -538,16 +538,17 @@ export class FlipperHit extends HitObject {
 		}
 
 		// here ball and flipper face are in contact... past the endpoints, also, don't forget embedded and near solution
-		const T = new Vertex2D();                          // flipper face tangent
+		const faceTangent = Vertex2D.claim();                // flipper face tangent
 		if (face1) {                                       // left face?
-			T.x = -faceNormal.y;
-			T.y = faceNormal.x;
+			faceTangent.x = -faceNormal.y;
+			faceTangent.y = faceNormal.x;
 		} else {                                           // rotate to form Tangent vector
-			T.x = faceNormal.y;
-			T.y = -faceNormal.x;
+			faceTangent.x = faceNormal.y;
+			faceTangent.y = -faceNormal.x;
 		}
 
-		const bfftd = ballVtx * T.x + ballVty * T.y;       // ball to flipper face tangent distance
+		const bfftd = ballVtx * faceTangent.x + ballVty * faceTangent.y;       // ball to flipper face tangent distance
+		Vertex2D.release(faceTangent);
 
 		const len = this.mover.flipperRadius * this.mover.zeroAngNorm.x;       // face segment length ... e.g. same on either face
 		if (bfftd < -C_TOL_ENDPNTS || bfftd > len + C_TOL_ENDPNTS) {

--- a/lib/vpt/flipper/flipper-hit.ts
+++ b/lib/vpt/flipper/flipper-hit.ts
@@ -39,7 +39,7 @@ import {
 	PHYS_TOUCH,
 } from '../../physics/constants';
 import { elasticityWithFalloff } from '../../physics/functions';
-import { HitObject, HitTestResult } from '../../physics/hit-object';
+import { HitObject } from '../../physics/hit-object';
 import { Ball } from '../ball/ball';
 import { Table } from '../table/table';
 import { TableData } from '../table/table-data';
@@ -106,9 +106,9 @@ export class FlipperHit extends HitObject {
 		);
 	}
 
-	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent): HitTestResult {
+	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent): number {
 		if (!this.data.isEnabled) {
-			return { hitTime: -1.0, coll };
+			return -1.0;
 		}
 		const lastFace = this.mover.lastHitFace;
 
@@ -120,30 +120,30 @@ export class FlipperHit extends HitObject {
 
 		let hitTime = this.hitTestFlipperFace(ball, dTime, coll, lastFace); // first face
 		if (hitTime >= 0) {
-			return { hitTime, coll };
+			return hitTime;
 		}
 
 		hitTime = this.hitTestFlipperFace(ball, dTime, coll, !lastFace); //second face
 		if (hitTime >= 0) {
 			this.mover.lastHitFace = !lastFace;                      // change this face to check first // HACK
-			return { hitTime, coll };
+			return hitTime;
 		}
 
 		hitTime = this.hitTestFlipperEnd(ball, dTime, coll);         // end radius
 		if (hitTime >= 0) {
-			return { hitTime, coll };
+			return hitTime;
 		}
 
-		({ hitTime, coll } = this.mover.hitCircleBase.hitTest(ball, dTime, coll));
+		hitTime = this.mover.hitCircleBase.hitTest(ball, dTime, coll);
 		if (hitTime >= 0) {
 			// Tangent velocity of contact point (rotate Normal right)
 			// units: rad*d/t (Radians*diameter/time)
 			coll.hitVel = new Vertex2D(0, 0);
 			coll.hitMomentBit = true;
-			return { hitTime, coll };
+			return hitTime;
 
 		} else {
-			return { hitTime: -1.0, coll }; // no hits
+			return -1.0; // no hits
 		}
 	}
 

--- a/lib/vpt/flipper/flipper-hit.ts
+++ b/lib/vpt/flipper/flipper-hit.ts
@@ -487,7 +487,7 @@ export class FlipperHit extends HitObject {
 
 				// test for already inside flipper plane, either embedded or beyond the face endpoints
 				if (bffnd < -(ball.data.radius + feRadius)) {
-					Vertex2D.release(faceNormal);
+					Vertex2D.release(faceNormal, vp);
 					return -1.0;                           // wrong side of face, or too deeply embedded
 				}
 				if (bffnd <= PHYS_TOUCH) {
@@ -499,7 +499,7 @@ export class FlipperHit extends HitObject {
 
 			} else if (k === 2) {                          // end pass two, check if zero crossing on initial interval, exit
 				if (dp * bffnd > 0.0) {
-					Vertex2D.release(faceNormal);
+					Vertex2D.release(faceNormal, vp);
 					return -1.0;                           // no solution ... no obvious zero crossing
 				}
 				t0 = 0;
@@ -709,6 +709,7 @@ export class FlipperHit extends HitObject {
 				// test for extreme conditions
 				if (bFend < -(ball.data.radius + feRadius)) {
 					// too deeply embedded, ambiguous position
+					Vertex2D.release(vp);
 					return -1.0;
 				}
 				if (bFend <= PHYS_TOUCH) {
@@ -723,6 +724,7 @@ export class FlipperHit extends HitObject {
 			} else if (k === 2) {                          // end pass two, check if zero crossing on initial interval, exit if none
 				if (dp * bFend > 0.0) {
 					// no solution ... no obvious zero crossing
+					Vertex2D.release(vp);
 					return -1.0;
 				}
 

--- a/lib/vpt/flipper/flipper-mover.spec.ts
+++ b/lib/vpt/flipper/flipper-mover.spec.ts
@@ -111,7 +111,7 @@ describe('The VPinball flipper physics', () => {
 		const flipperState = flipper.getState();
 		const states = player.popStates();
 
-		const poppedState = states.FlipperR.newState;
+		const poppedState = states.getState<FlipperState>('FlipperR').newState;
 
 		expect(flipperState).to.equal(poppedState);
 		expect(flipperState.equals(undefined as unknown as FlipperState)).to.equal(false);

--- a/lib/vpt/flipper/flipper-mover.spec.ts
+++ b/lib/vpt/flipper/flipper-mover.spec.ts
@@ -113,8 +113,9 @@ describe('The VPinball flipper physics', () => {
 
 		const poppedState = states.getState<FlipperState>('FlipperR').newState;
 
-		expect(flipperState).to.equal(poppedState);
+		expect(flipperState).to.eql(poppedState);
 		expect(flipperState.equals(undefined as unknown as FlipperState)).to.equal(false);
+		states.release();
 	});
 
 });

--- a/lib/vpt/flipper/flipper-state.ts
+++ b/lib/vpt/flipper/flipper-state.ts
@@ -17,20 +17,35 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-/* tslint:disable:variable-name */
-
+import { Pool } from '../../util/object-pool';
 import { ItemState } from '../item-state';
 
 export class FlipperState extends ItemState {
 
+	public static readonly POOL = new Pool(FlipperState);
+
 	/**
 	 * Angle in rad
 	 */
-	public angle: number;
+	public angle: number = 0;
 
-	constructor(name: string, angle: number) {
-		super(name);
-		this.angle = angle;
+	public constructor() {
+		super();
+	}
+
+	public static claim(name: string, angle: number): FlipperState {
+		const state = FlipperState.POOL.get();
+		state.name = name;
+		state.angle = angle;
+		return state;
+	}
+
+	public clone(): FlipperState {
+		return FlipperState.claim(this.name, this.angle);
+	}
+
+	public release(): void {
+		FlipperState.POOL.release(this);
 	}
 
 	public equals(state: FlipperState): boolean {
@@ -39,9 +54,5 @@ export class FlipperState extends ItemState {
 			return false;
 		}
 		return state.angle === this.angle;
-	}
-
-	public clone(): FlipperState {
-		return new FlipperState(this.name, this.angle);
 	}
 }

--- a/lib/vpt/flipper/flipper.ts
+++ b/lib/vpt/flipper/flipper.ts
@@ -128,13 +128,13 @@ export class Flipper implements IRenderable, IPlayable, IMovable<FlipperState>, 
 	public applyState(obj: Object3D, table: Table): void {
 		const height = table.getSurfaceHeight(this.data.szSurface, this.data.center.x, this.data.center.y) * table.getScaleZ();
 
-		const matToOrigin = new Matrix3D().setTranslation(-this.data.center.x, -this.data.center.y, -height);
-		const matFromOrigin = new Matrix3D().setTranslation(this.data.center.x, this.data.center.y, height);
-		const matRotate = new Matrix3D().rotateZMatrix(this.state.angle - degToRad(this.data.startAngle));
+		const matToOrigin = Matrix3D.claim().setTranslation(-this.data.center.x, -this.data.center.y, -height);
+		const matFromOrigin = Matrix3D.claim().setTranslation(this.data.center.x, this.data.center.y, height);
+		const matRotate = Matrix3D.claim().rotateZMatrix(this.state.angle - degToRad(this.data.startAngle));
 		const matrix = matToOrigin.multiply(matRotate).multiply(matFromOrigin);
 
-		obj.matrix = matrix.toThreeMatrix4();
-		obj.matrixWorldNeedsUpdate = true;
+		matrix.applyToObject3D(obj);
+		Matrix3D.release(matToOrigin, matFromOrigin, matRotate); // matrix and matToOrigin are the same instance
 	}
 
 	public getFlipperData(): FlipperData {

--- a/lib/vpt/flipper/flipper.ts
+++ b/lib/vpt/flipper/flipper.ts
@@ -61,7 +61,7 @@ export class Flipper implements IRenderable, IPlayable, IMovable<FlipperState>, 
 	public constructor(itemName: string, data: FlipperData) {
 		this.data = data;
 		this.mesh = new FlipperMesh();
-		this.state = new FlipperState(this.getName(), this.data.startAngle);
+		this.state = FlipperState.claim(this.getName(), this.data.startAngle);
 	}
 
 	public isVisible(): boolean {

--- a/lib/vpt/flipper/flipper.ts
+++ b/lib/vpt/flipper/flipper.ts
@@ -105,12 +105,12 @@ export class Flipper implements IRenderable, IPlayable, IMovable<FlipperState>, 
 	public getMeshes(table: Table): Meshes {
 		const meshes: Meshes = {};
 
-		const matrix = this.getMatrix();
+		const matrix = this.getMatrix().toRightHanded();
 		const flipper = this.mesh.generateMeshes(this.data, table);
 
 		// base mesh
 		meshes.base = {
-			mesh: flipper.base.transform(matrix.toRightHanded()),
+			mesh: flipper.base.transform(matrix),
 			material: table.getMaterial(this.data.szMaterial),
 			map: table.getTexture(this.data.szImage),
 		};
@@ -118,7 +118,7 @@ export class Flipper implements IRenderable, IPlayable, IMovable<FlipperState>, 
 		// rubber mesh
 		if (flipper.rubber) {
 			meshes.rubber = {
-				mesh: flipper.rubber.transform(matrix.toRightHanded()),
+				mesh: flipper.rubber.transform(matrix),
 				material: table.getMaterial(this.data.szRubberMaterial),
 			};
 		}
@@ -143,10 +143,12 @@ export class Flipper implements IRenderable, IPlayable, IMovable<FlipperState>, 
 
 	private getMatrix(rotation: number = this.data.startAngle): Matrix3D {
 		const trafoMatrix = new Matrix3D();
-		const tempMatrix = new Matrix3D();
+		const tempMatrix = Matrix3D.claim();
 		trafoMatrix.setTranslation(this.data.center.x, this.data.center.y, 0);
 		tempMatrix.rotateZMatrix(degToRad(rotation));
 		trafoMatrix.preMultiply(tempMatrix);
+
+		Matrix3D.release(tempMatrix);
 		return trafoMatrix;
 	}
 

--- a/lib/vpt/gate/gate-hit-generator.ts
+++ b/lib/vpt/gate/gate-hit-generator.ts
@@ -47,8 +47,8 @@ export class GateHitGenerator {
 		this.data.angleMax = angleMax;
 
 		const rgv: Vertex2D[] = [ //oversize by the ball's radius to prevent the ball from clipping through
-			this.data.vCenter.clone().add(tangent.clone().multiplyScalar(halfLength + PHYS_SKIN)),
-			this.data.vCenter.clone().sub(tangent.clone().multiplyScalar(halfLength + PHYS_SKIN)),
+			this.data.vCenter.clone().addAndRelease(tangent.clone(true).multiplyScalar(halfLength + PHYS_SKIN)),
+			this.data.vCenter.clone().subAndRelease(tangent.clone(true).multiplyScalar(halfLength + PHYS_SKIN)),
 		];
 		const lineSeg = new LineSeg(rgv[0], rgv[1], height, height + 2.0 * PHYS_SKIN); //!! = ball diameter
 
@@ -72,8 +72,8 @@ export class GateHitGenerator {
 		const halfLength = this.data.length * 0.5;
 		if (this.data.showBracket) {
 			return [
-				new HitCircle(this.data.vCenter.clone().add(tangent.clone().multiplyScalar(halfLength)), 0.01, height, height + this.data.height),
-				new HitCircle(this.data.vCenter.clone().sub(tangent.clone().multiplyScalar(halfLength)), 0.01, height, height + this.data.height),
+				new HitCircle(this.data.vCenter.clone().addAndRelease(tangent.clone(true).multiplyScalar(halfLength)), 0.01, height, height + this.data.height),
+				new HitCircle(this.data.vCenter.clone().subAndRelease(tangent.clone(true).multiplyScalar(halfLength)), 0.01, height, height + this.data.height),
 			];
 		} else {
 			return [];

--- a/lib/vpt/gate/gate-hit.ts
+++ b/lib/vpt/gate/gate-hit.ts
@@ -24,7 +24,7 @@ import { Vertex2D } from '../../math/vertex2d';
 import { CollisionEvent } from '../../physics/collision-event';
 import { CollisionType } from '../../physics/collision-type';
 import { PHYS_SKIN } from '../../physics/constants';
-import { HitObject, HitTestResult } from '../../physics/hit-object';
+import { HitObject } from '../../physics/hit-object';
 import { LineSeg } from '../../physics/line-seg';
 import { Ball } from '../ball/ball';
 import { GateData } from './gate-data';
@@ -79,20 +79,20 @@ export class GateHit extends HitObject {
 		this.hitBBox = this.lineSeg[0].hitBBox;
 	}
 
-	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent, physics: PlayerPhysics): HitTestResult {
+	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent, physics: PlayerPhysics): number {
 		if (!this.isEnabled) {
-			return {hitTime: -1.0, coll};
+			return -1.0;
 		}
 
 		for (let i = 0; i < 2; ++i) {
-			const result = this.lineSeg[i].hitTestBasic(ball, dTime, coll, false, true, false); // any face, lateral, non-rigid
-			if (result.hitTime >= 0) {
+			const hitTime = this.lineSeg[i].hitTestBasic(ball, dTime, coll, false, true, false); // any face, lateral, non-rigid
+			if (hitTime >= 0) {
 				// signal the Collide() function that the hit is on the front or back side
 				coll.hitFlag = !!i;
-				return {hitTime: result.hitTime, coll};
+				return hitTime;
 			}
 		}
-		return {hitTime: -1.0, coll};
+		return -1.0;
 	}
 
 	public collide(coll: CollisionEvent, physics: PlayerPhysics): void {

--- a/lib/vpt/gate/gate-hit.ts
+++ b/lib/vpt/gate/gate-hit.ts
@@ -97,7 +97,7 @@ export class GateHit extends HitObject {
 
 	public collide(coll: CollisionEvent, physics: PlayerPhysics): void {
 		const ball = coll.ball;
-		const hitNormal = coll.hitNormal!;
+		const hitNormal = coll.hitNormal;
 
 		const dot = hitNormal.dot(coll.ball.hit.vel);
 		const h = this.data.height * 0.5;

--- a/lib/vpt/gate/gate-mesh-generator.ts
+++ b/lib/vpt/gate/gate-mesh-generator.ts
@@ -74,17 +74,17 @@ export class GateMeshGenerator {
 		fullMatrix.rotateZMatrix(degToRad(this.data.rotation));
 		for (const vertex of mesh.vertices) {
 
-			let vert = new Vertex3D(vertex.x, vertex.y, vertex.z);
-			vert = fullMatrix.multiplyVector(vert);
+			const vert = Vertex3D.claim(vertex.x, vertex.y, vertex.z).multiplyMatrix(fullMatrix);
 			vertex.x = f4(vert.x * this.data.length) + this.data.vCenter.x;
 			vertex.y = f4(vert.y * this.data.length) + this.data.vCenter.y;
 			vertex.z = f4(f4(f4(vert.z * this.data.length) * table.getScaleZ()) + f4(this.data.height * table.getScaleZ())) + baseHeight;
 
-			vert = new Vertex3D(vertex.nx, vertex.ny, vertex.nz);
-			vert = fullMatrix.multiplyVectorNoTranslate(vert);
-			vertex.nx = vert.x;
-			vertex.ny = vert.y;
-			vertex.nz = vert.z;
+			const normal = Vertex3D.claim(vertex.nx, vertex.ny, vertex.nz).multiplyMatrixNoTranslate(fullMatrix);
+			vertex.nx = normal.x;
+			vertex.ny = normal.y;
+			vertex.nz = normal.z;
+
+			Vertex3D.release(vert, normal);
 		}
 		return mesh;
 	}

--- a/lib/vpt/gate/gate-mover.spec.ts
+++ b/lib/vpt/gate/gate-mover.spec.ts
@@ -125,7 +125,7 @@ describe('The VPinball gate mover', () => {
 		const gateState = gate.getState();
 		const states = player.popStates();
 
-		const poppedState = states.WireRectangle.newState;
+		const poppedState = states.getState<GateState>('WireRectangle').newState;
 
 		expect(gateState).to.equal(poppedState);
 		expect(gateState.equals(undefined as unknown as GateState)).to.equal(false);

--- a/lib/vpt/gate/gate-mover.spec.ts
+++ b/lib/vpt/gate/gate-mover.spec.ts
@@ -127,7 +127,7 @@ describe('The VPinball gate mover', () => {
 
 		const poppedState = states.getState<GateState>('WireRectangle').newState;
 
-		expect(gateState).to.equal(poppedState);
+		expect(gateState).to.eql(poppedState);
 		expect(gateState.equals(undefined as unknown as GateState)).to.equal(false);
 	});
 

--- a/lib/vpt/gate/gate-state.ts
+++ b/lib/vpt/gate/gate-state.ts
@@ -17,18 +17,35 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { Pool } from '../../util/object-pool';
 import { ItemState } from '../item-state';
 
 export class GateState extends ItemState {
 
+	public static readonly POOL = new Pool(GateState);
+
 	/**
 	 * Angle in rad
 	 */
-	public angle: number;
+	public angle: number = 0;
 
-	constructor(name: string, angle: number) {
-		super(name);
-		this.angle = angle;
+	public constructor() {
+		super();
+	}
+
+	public static claim(name: string, angle: number): GateState {
+		const state = GateState.POOL.get();
+		state.name = name;
+		state.angle = angle;
+		return state;
+	}
+
+	public clone(): GateState {
+		return GateState.claim(this.name, this.angle);
+	}
+
+	public release(): void {
+		GateState.POOL.release(this);
 	}
 
 	public equals(state: GateState): boolean {
@@ -37,9 +54,5 @@ export class GateState extends ItemState {
 			return false;
 		}
 		return state.angle === this.angle;
-	}
-
-	public clone(): GateState {
-		return new GateState(this.name, this.angle);
 	}
 }

--- a/lib/vpt/gate/gate.ts
+++ b/lib/vpt/gate/gate.ts
@@ -17,7 +17,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { Matrix4, Object3D } from 'three';
+import { Object3D } from 'three';
 import { EventProxy } from '../../game/event-proxy';
 import { IHittable } from '../../game/ihittable';
 import { IMovable } from '../../game/imovable';

--- a/lib/vpt/gate/gate.ts
+++ b/lib/vpt/gate/gate.ts
@@ -94,14 +94,14 @@ export class Gate implements IRenderable, IPlayable, IMovable<GateState>, IHitta
 
 		// wire mesh
 		meshes.wire = {
-			mesh: gate.wire.transform(new Matrix3D().toRightHanded()),
+			mesh: gate.wire.transform(Matrix3D.RIGHT_HANDED),
 			material: table.getMaterial(this.data.szMaterial),
 		};
 
 		// bracket mesh
 		if (gate.bracket) {
 			meshes.bracket = {
-				mesh: gate.bracket.transform(new Matrix3D().toRightHanded()),
+				mesh: gate.bracket.transform(Matrix3D.RIGHT_HANDED),
 				material: table.getMaterial(this.data.szMaterial),
 			};
 		}

--- a/lib/vpt/gate/gate.ts
+++ b/lib/vpt/gate/gate.ts
@@ -143,11 +143,11 @@ export class Gate implements IRenderable, IPlayable, IMovable<GateState>, IHitta
 	/* istanbul ignore next */
 	public applyState(obj: Object3D, table: Table, player: Player, oldState: GateState): void {
 		const posZ = this.data.height;
-		const matTransToOrigin = new Matrix3D().setTranslation(-this.data.vCenter.x, -this.data.vCenter.y, posZ);
-		const matRotateToOrigin = new Matrix3D().rotateZMatrix(degToRad(-this.data.rotation));
-		const matTransFromOrigin = new Matrix3D().setTranslation(this.data.vCenter.x, this.data.vCenter.y, -posZ);
-		const matRotateFromOrigin = new Matrix3D().rotateZMatrix(degToRad(this.data.rotation));
-		const matRotateX = new Matrix3D().rotateXMatrix(this.state.angle - degToRad(this.data.angleMin));
+		const matTransToOrigin = Matrix3D.claim().setTranslation(-this.data.vCenter.x, -this.data.vCenter.y, posZ);
+		const matRotateToOrigin = Matrix3D.claim().rotateZMatrix(degToRad(-this.data.rotation));
+		const matTransFromOrigin = Matrix3D.claim().setTranslation(this.data.vCenter.x, this.data.vCenter.y, -posZ);
+		const matRotateFromOrigin = Matrix3D.claim().rotateZMatrix(degToRad(this.data.rotation));
+		const matRotateX = Matrix3D.claim().rotateXMatrix(this.state.angle - degToRad(this.data.angleMin));
 
 		const matrix = matTransToOrigin
 			.multiply(matRotateToOrigin)
@@ -156,8 +156,9 @@ export class Gate implements IRenderable, IPlayable, IMovable<GateState>, IHitta
 			.multiply(matTransFromOrigin);
 
 		const wireObj = obj.children.find(c => c.name === `gate.wire-${this.data.getName()}`)!;
-		wireObj.matrix = new Matrix4();
-		wireObj.applyMatrix(matrix.toThreeMatrix4());
+		matrix.applyToObject3D(wireObj);
+
+		Matrix3D.release(matTransToOrigin, matRotateToOrigin, matTransFromOrigin, matRotateFromOrigin, matRotateX);
 	}
 
 	public getEventNames(): string[] {

--- a/lib/vpt/gate/gate.ts
+++ b/lib/vpt/gate/gate.ts
@@ -71,7 +71,7 @@ export class Gate implements IRenderable, IPlayable, IMovable<GateState>, IHitta
 
 	private constructor(data: GateData) {
 		this.data = data;
-		this.state = new GateState(this.getName(), 0);
+		this.state = GateState.claim(this.getName(), 0);
 		this.meshGenerator = new GateMeshGenerator(data);
 		this.hitGenerator = new GateHitGenerator(data);
 	}

--- a/lib/vpt/hit-target/hit-target-hit-generator.ts
+++ b/lib/vpt/hit-target/hit-target-hit-generator.ts
@@ -73,11 +73,11 @@ export class HitTargetHitGenerator {
 
 			// now create a special hit shape with hit event enabled to prevent a hit event when hit from behind
 			for (const dropTargetHitPlaneVertex of dropTargetHitPlaneVertices) {
-				let vert = new Vertex3D(dropTargetHitPlaneVertex.x, dropTargetHitPlaneVertex.y + hitShapeOffset, dropTargetHitPlaneVertex.z);
+				const vert = new Vertex3D(dropTargetHitPlaneVertex.x, dropTargetHitPlaneVertex.y + hitShapeOffset, dropTargetHitPlaneVertex.z);
 				vert.x *= this.data.vSize.x;
 				vert.y *= this.data.vSize.y;
 				vert.z *= this.data.vSize.z;
-				vert = fullMatrix.multiplyVector(vert);
+				vert.multiplyMatrix(fullMatrix);
 				rgv3D.push(new Vertex3D(
 					vert.x + this.data.vPosition.x,
 					vert.y + this.data.vPosition.y,

--- a/lib/vpt/hit-target/hit-target-hit.spec.ts
+++ b/lib/vpt/hit-target/hit-target-hit.spec.ts
@@ -141,7 +141,7 @@ describe('The VPinball hit target collision', () => {
 		dropTarget.IsDropped = true;
 
 		player.updatePhysics(200);
-		const state = player.popStates().DropTargetBeveled.newState as HitTargetState;
+		const state = player.popStates().getState<HitTargetState>('DropTargetBeveled').newState;
 		expect(state.zOffset).to.equal(table.hitTargets.DropTargetBeveled.getState().zOffset);
 	});
 });

--- a/lib/vpt/hit-target/hit-target-mesh-generator.ts
+++ b/lib/vpt/hit-target/hit-target-mesh-generator.ts
@@ -60,21 +60,22 @@ export class HitTargetMeshGenerator {
 		fullMatrix.multiply(tempMatrix);
 
 		for (const vertex of hitTargetMesh.vertices) {
-			let vert = new Vertex3D(vertex.x, vertex.y, vertex.z);
+			const vert = Vertex3D.claim(vertex.x, vertex.y, vertex.z);
 			vert.x *= this.data.vSize.x;
 			vert.y *= this.data.vSize.y;
 			vert.z *= this.data.vSize.z;
-			vert = fullMatrix.multiplyVector(vert);
+			vert.multiplyMatrix(fullMatrix);
 
 			vertex.x = f4(vert.x + this.data.vPosition.x);
 			vertex.y = f4(vert.y + this.data.vPosition.y);
 			vertex.z = f4(f4(f4(vert.z * table.getScaleZ()) + this.data.vPosition.z) + table.getTableHeight()) + dropOffset;
 
-			vert = new Vertex3D(vertex.nx, vertex.ny, vertex.nz);
-			vert = fullMatrix.multiplyVectorNoTranslate(vert);
-			vertex.nx = vert.x;
-			vertex.ny = vert.y;
-			vertex.nz = vert.z;
+			const normal = Vertex3D.claim(vertex.nx, vertex.ny, vertex.nz).multiplyMatrixNoTranslate(fullMatrix);
+			vertex.nx = normal.x;
+			vertex.ny = normal.y;
+			vertex.nz = normal.z;
+
+			Vertex3D.release(vert, normal);
 		}
 
 		return hitTargetMesh;

--- a/lib/vpt/hit-target/hit-target-state.ts
+++ b/lib/vpt/hit-target/hit-target-state.ts
@@ -17,17 +17,34 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { Pool } from '../../util/object-pool';
 import { ItemState } from '../item-state';
 
 export class HitTargetState extends ItemState {
 
-	public zOffset: number;
-	public xRotation: number;
+	public static readonly POOL = new Pool(HitTargetState);
 
-	constructor(name: string, zOffset: number = 0, xRotation = 0) {
-		super(name);
-		this.zOffset = zOffset;
-		this.xRotation = xRotation;
+	public zOffset: number = 0;
+	public xRotation: number = 0;
+
+	public constructor() {
+		super();
+	}
+
+	public static claim(name: string, zOffset: number = 0, xRotation = 0): HitTargetState {
+		const state = HitTargetState.POOL.get();
+		state.name = name;
+		state.zOffset = zOffset;
+		state.xRotation = xRotation;
+		return state;
+	}
+
+	public clone(): HitTargetState {
+		return HitTargetState.claim(this.name, this.zOffset, this.xRotation);
+	}
+
+	public release(): void {
+		HitTargetState.POOL.release(this);
 	}
 
 	public equals(state: HitTargetState): boolean {
@@ -36,9 +53,5 @@ export class HitTargetState extends ItemState {
 			return false;
 		}
 		return state.zOffset === this.zOffset && state.xRotation === this.xRotation;
-	}
-
-	public clone(): HitTargetState {
-		return new HitTargetState(this.name, this.zOffset, this.xRotation);
 	}
 }

--- a/lib/vpt/hit-target/hit-target.ts
+++ b/lib/vpt/hit-target/hit-target.ts
@@ -94,7 +94,7 @@ export class HitTarget implements IRenderable, IHittable, IAnimatable<HitTargetS
 	public getMeshes(table: Table): Meshes {
 		return {
 			hitTarget: {
-				mesh: this.meshGenerator.getMesh(table).transform(new Matrix3D().toRightHanded()),
+				mesh: this.meshGenerator.getMesh(table).transform(Matrix3D.RIGHT_HANDED),
 				map: table.getTexture(this.data.szImage),
 				material: table.getMaterial(this.data.szMaterial),
 			},

--- a/lib/vpt/hit-target/hit-target.ts
+++ b/lib/vpt/hit-target/hit-target.ts
@@ -139,20 +139,21 @@ export class HitTarget implements IRenderable, IHittable, IAnimatable<HitTargetS
 	}
 
 	public applyState(obj: Object3D, table: Table, player: Player, oldState: HitTargetState): void {
-		const matTransToOrigin = new Matrix3D().setTranslation(-this.data.vPosition.x, -this.data.vPosition.y, -this.data.vPosition.z);
-		const matRotateToOrigin = new Matrix3D().rotateZMatrix(degToRad(-this.data.rotZ));
-		const matTransFromOrigin = new Matrix3D().setTranslation(this.data.vPosition.x, this.data.vPosition.y, this.data.vPosition.z);
-		const matRotateFromOrigin = new Matrix3D().rotateZMatrix(degToRad(this.data.rotZ));
-		const matRotateX = new Matrix3D().rotateXMatrix(degToRad(this.state.xRotation));
-		const matTranslateZ = new Matrix3D().setTranslation(0, 0, -this.state.zOffset);
+		const matTransToOrigin = Matrix3D.claim().setTranslation(-this.data.vPosition.x, -this.data.vPosition.y, -this.data.vPosition.z);
+		const matRotateToOrigin = Matrix3D.claim().rotateZMatrix(degToRad(-this.data.rotZ));
+		const matTransFromOrigin = Matrix3D.claim().setTranslation(this.data.vPosition.x, this.data.vPosition.y, this.data.vPosition.z);
+		const matRotateFromOrigin = Matrix3D.claim().rotateZMatrix(degToRad(this.data.rotZ));
+		const matRotateX = Matrix3D.claim().rotateXMatrix(degToRad(this.state.xRotation));
+		const matTranslateZ = Matrix3D.claim().setTranslation(0, 0, -this.state.zOffset);
 		const matrix = matTransToOrigin
 			.multiply(matRotateToOrigin)
 			.multiply(matRotateX)
 			.multiply(matTranslateZ)
 			.multiply(matRotateFromOrigin)
 			.multiply(matTransFromOrigin);
-		obj.matrix = new Matrix4();
-		obj.applyMatrix(matrix.toThreeMatrix4());
+
+		matrix.applyToObject3D(obj);
+		Matrix3D.release(matTransToOrigin, matRotateToOrigin, matTransFromOrigin, matRotateFromOrigin, matRotateX, matTranslateZ);
 	}
 
 	public setCollidable(isCollidable: boolean) {

--- a/lib/vpt/hit-target/hit-target.ts
+++ b/lib/vpt/hit-target/hit-target.ts
@@ -17,7 +17,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { Matrix4, Object3D } from 'three';
+import { Object3D } from 'three';
 import { EventProxy } from '../../game/event-proxy';
 import { IAnimatable, IAnimation } from '../../game/ianimatable';
 import { IHittable } from '../../game/ihittable';

--- a/lib/vpt/hit-target/hit-target.ts
+++ b/lib/vpt/hit-target/hit-target.ts
@@ -74,7 +74,7 @@ export class HitTarget implements IRenderable, IHittable, IAnimatable<HitTargetS
 
 	private constructor(data: HitTargetData) {
 		this.data = data;
-		this.state = new HitTargetState(this.data.getName());
+		this.state = HitTargetState.claim(this.data.getName());
 		this.meshGenerator = new HitTargetMeshGenerator(data);
 		this.hitGenerator = new HitTargetHitGenerator(data, this.meshGenerator);
 	}

--- a/lib/vpt/item-state.ts
+++ b/lib/vpt/item-state.ts
@@ -19,14 +19,17 @@
 
 export abstract class ItemState {
 
-	protected readonly name: string;
+	protected name: string = '';
 
-	public constructor(name: string) {
-		this.name = name;
+	protected constructor(name?: string) {
+		if (name) {
+			this.name = name;
+		}
 	}
 
 	public abstract clone(): ItemState;
 	public abstract equals(state: ItemState): boolean;
+	public abstract release(): void;
 
 	public getName() {
 		return this.name;

--- a/lib/vpt/item-state.ts
+++ b/lib/vpt/item-state.ts
@@ -27,6 +27,12 @@ export abstract class ItemState {
 		}
 	}
 
+	/**
+	 * Clones the state.
+	 *
+	 * Note that returned clone is always recycled (i.e. retrieved from the object
+	 * pool), so it should be released after usage.
+	 */
 	public abstract clone(): ItemState;
 	public abstract equals(state: ItemState): boolean;
 	public abstract release(): void;

--- a/lib/vpt/kicker/kicker-hit.ts
+++ b/lib/vpt/kicker/kicker-hit.ts
@@ -23,7 +23,6 @@ import { EventProxy } from '../../game/event-proxy';
 import { PlayerPhysics } from '../../game/player-physics';
 import { degToRad } from '../../math/float';
 import { clamp } from '../../math/functions';
-import { Vertex2D } from '../../math/vertex2d';
 import { Vertex3D } from '../../math/vertex3d';
 import { CollisionEvent } from '../../physics/collision-event';
 import { CollisionType } from '../../physics/collision-type';

--- a/lib/vpt/kicker/kicker-hit.ts
+++ b/lib/vpt/kicker/kicker-hit.ts
@@ -71,7 +71,7 @@ export class KickerHit extends HitCircle {
 	}
 
 	public collide(coll: CollisionEvent, physics: PlayerPhysics): void {
-		this.doCollide(physics, coll.ball, coll.hitNormal!, coll.hitFlag, false);
+		this.doCollide(physics, coll.ball, coll.hitNormal, coll.hitFlag, false);
 	}
 
 	public doCollide(physics: PlayerPhysics, ball: Ball, hitNormal: Vertex3D, hitBit: boolean, newBall: boolean) {
@@ -256,8 +256,8 @@ export class KickerHit extends HitCircle {
 		this.ball.hit.angularMomentum.setZero();
 		this.ball.hit.coll.hitDistance = 0.0;
 		this.ball.hit.coll.hitTime = -1.0;
-		this.ball.hit.coll.hitNormal = new Vertex3D();
-		this.ball.hit.coll.hitVel = new Vertex2D();
+		this.ball.hit.coll.hitNormal.setZero();
+		this.ball.hit.coll.hitVel.setZero();
 		this.ball.hit.coll.hitFlag = false;
 		this.ball.hit.coll.isContact = false;
 		this.ball.hit.coll.hitMomentBit = true;

--- a/lib/vpt/kicker/kicker-hit.ts
+++ b/lib/vpt/kicker/kicker-hit.ts
@@ -28,7 +28,7 @@ import { Vertex3D } from '../../math/vertex3d';
 import { CollisionEvent } from '../../physics/collision-event';
 import { CollisionType } from '../../physics/collision-type';
 import { STATICTIME } from '../../physics/constants';
-import { hardScatter } from '../../physics/functions';
+import { HARD_SCATTER } from '../../physics/functions';
 import { HitCircle } from '../../physics/hit-circle';
 import { Ball } from '../ball/ball';
 import { FLT_MAX } from '../mesh';
@@ -237,7 +237,7 @@ export class KickerHit extends HitCircle {
 		}
 
 		let scatterAngle = this.data.scatter < 0.0                             // if < 0 use global value
-			? hardScatter
+			? HARD_SCATTER
 			: degToRad(this.data.scatter);
 		scatterAngle *= table.getGlobalDifficulty();                           // apply difficulty weighting
 

--- a/lib/vpt/kicker/kicker-hit.ts
+++ b/lib/vpt/kicker/kicker-hit.ts
@@ -30,7 +30,6 @@ import { CollisionType } from '../../physics/collision-type';
 import { STATICTIME } from '../../physics/constants';
 import { hardScatter } from '../../physics/functions';
 import { HitCircle } from '../../physics/hit-circle';
-import { HitTestResult } from '../../physics/hit-object';
 import { Ball } from '../ball/ball';
 import { FLT_MAX } from '../mesh';
 import { Table } from '../table/table';
@@ -66,7 +65,7 @@ export class KickerHit extends HitCircle {
 		this.obj = events;
 	}
 
-	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent): HitTestResult {
+	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent): number {
 		// any face, not-lateral, non-rigid
 		return this.hitTestBasicRadius(ball, dTime, coll, false, false, false);
 	}

--- a/lib/vpt/kicker/kicker-mesh-generator.ts
+++ b/lib/vpt/kicker/kicker-mesh-generator.ts
@@ -67,18 +67,17 @@ export class KickerMeshGenerator {
 
 		const mesh = this.getBaseMesh();
 		for (const vertex of mesh.vertices) {
-			let vert = new Vertex3D(vertex.x, vertex.y, vertex.z + zOffset);
-			vert = fullMatrix.multiplyVector(vert);
-
+			const vert = Vertex3D.claim(vertex.x, vertex.y, vertex.z + zOffset).multiplyMatrix(fullMatrix);
 			vertex.x = f4(vert.x * this.data.radius) + this.data.vCenter.x;
 			vertex.y = f4(vert.y * this.data.radius) + this.data.vCenter.y;
 			vertex.z = f4(f4(vert.z * this.data.radius) * table.getScaleZ()) + baseHeight;
 
-			vert = new Vertex3D(vertex.nx, vertex.ny, vertex.nz);
-			vert = fullMatrix.multiplyVectorNoTranslate(vert);
-			vertex.nx = vert.x;
-			vertex.ny = vert.y;
-			vertex.nz = vert.z;
+			const normal = Vertex3D.claim(vertex.nx, vertex.ny, vertex.nz).multiplyMatrixNoTranslate(fullMatrix);
+			vertex.nx = normal.x;
+			vertex.ny = normal.y;
+			vertex.nz = normal.z;
+
+			Vertex3D.release(vert, normal);
 		}
 		return mesh;
 	}

--- a/lib/vpt/kicker/kicker.ts
+++ b/lib/vpt/kicker/kicker.ts
@@ -125,7 +125,7 @@ export class Kicker extends EventEmitter implements IRenderable, IHittable, IBal
 	}
 
 	public onBallCreated(physics: PlayerPhysics, ball: Ball): void {
-		ball.getCollision().hitFlag = true;                        // HACK: avoid capture leaving kicker
+		ball.coll.hitFlag = true;                        // HACK: avoid capture leaving kicker
 		const hitNormal = new Vertex3D(FLT_MAX, FLT_MAX, FLT_MAX); // unused due to newBall being true
 		this.hit!.doCollide(physics, ball, hitNormal, false, true);
 	}

--- a/lib/vpt/kicker/kicker.ts
+++ b/lib/vpt/kicker/kicker.ts
@@ -89,7 +89,7 @@ export class Kicker extends EventEmitter implements IRenderable, IHittable, IBal
 	public getMeshes(table: Table): Meshes {
 		return {
 			kicker: {
-				mesh: this.meshGenerator.getMesh(table).transform(new Matrix3D().toRightHanded()),
+				mesh: this.meshGenerator.getMesh(table).transform(Matrix3D.RIGHT_HANDED),
 				material: table.getMaterial(this.data.szMaterial),
 				map: this.getTexture(),
 			},

--- a/lib/vpt/light/light.ts
+++ b/lib/vpt/light/light.ts
@@ -95,7 +95,7 @@ export class Light implements IRenderable {
 			lightMaterial.emissiveIntensity = 1;
 
 			meshes.light = {
-				mesh: light.light.transform(new Matrix3D().toRightHanded()),
+				mesh: light.light.transform(Matrix3D.RIGHT_HANDED),
 				material: lightMaterial,
 			};
 		}
@@ -116,7 +116,7 @@ export class Light implements IRenderable {
 			socketMaterial.cClearcoat = 0;
 
 			meshes.socket = {
-				mesh: light.socket.transform(new Matrix3D().toRightHanded()),
+				mesh: light.socket.transform(Matrix3D.RIGHT_HANDED),
 				material: socketMaterial,
 			};
 		}

--- a/lib/vpt/mesh.ts
+++ b/lib/vpt/mesh.ts
@@ -152,14 +152,15 @@ export class Mesh {
 			const B = vertices[indices[i + 1]];
 			const C = vertices[indices[i + 2]];
 
-			const e0 = new Vertex3D(B.x - A.x, B.y - A.y, B.z - A.z);
-			const e1 = new Vertex3D(C.x - A.x, C.y - A.y, C.z - A.z);
-			const normal = e0.clone().cross(e1);
-			normal.normalize();
+			const e0 = Vertex3D.claim(B.x - A.x, B.y - A.y, B.z - A.z);
+			const e1 = Vertex3D.claim(C.x - A.x, C.y - A.y, C.z - A.z);
+			const normal = e0.clone(true).cross(e1).normalize();
 
 			A.nx += normal.x; A.ny += normal.y; A.nz += normal.z;
 			B.nx += normal.x; B.ny += normal.y; B.nz += normal.z;
 			C.nx += normal.x; C.ny += normal.y; C.nz += normal.z;
+
+			Vertex3D.release(e0, e1, normal);
 		}
 
 		for (let i = 0; i < numVertices; i++) {

--- a/lib/vpt/mesh.ts
+++ b/lib/vpt/mesh.ts
@@ -85,17 +85,17 @@ export class Mesh {
 
 	public transform(matrix: Matrix3D, normalMatrix?: Matrix3D, getZ?: (x: number) => number): this {
 		for (const vertex of this.vertices) {
-			let vert = new Vertex3D(vertex.x, vertex.y, vertex.z);
-			vert = matrix.multiplyVector(vert);
+			const vert = Vertex3D.claim(vertex.x, vertex.y, vertex.z).multiplyMatrix(matrix);
 			vertex.x = vert.x;
 			vertex.y = vert.y;
 			vertex.z = getZ ? getZ(vert.z) : vert.z;
 
-			let norm = new Vertex3D(vertex.nx, vertex.ny, vertex.nz);
-			norm = (normalMatrix || matrix).multiplyVectorNoTranslate(norm);
+			const norm = Vertex3D.claim(vertex.nx, vertex.ny, vertex.nz).multiplyMatrixNoTranslate(normalMatrix || matrix);
 			vertex.nx = norm.x;
 			vertex.ny = norm.y;
 			vertex.nz = norm.z;
+
+			Vertex3D.release(vert, norm);
 		}
 		return this;
 	}

--- a/lib/vpt/plunger/plunger-hit.ts
+++ b/lib/vpt/plunger/plunger-hit.ts
@@ -90,7 +90,7 @@ export class PlungerHit extends HitObject {
 			isHit = true;
 			hitTime = newTime;
 			coll.set(hit);
-			coll.hitVel = new Vertex2D(0, 0);
+			coll.hitVel.set(0, 0);
 		}
 
 		for (let i = 0; i < 2; i++) {
@@ -99,7 +99,7 @@ export class PlungerHit extends HitObject {
 				isHit = true;
 				hitTime = newTime;
 				coll.set(hit);
-				coll.hitVel = new Vertex2D(0, 0);
+				coll.hitVel.set(0, 0);
 			}
 
 			newTime = this.mover.jointBase[i].hitTest(ball, hitTime, hit);
@@ -107,7 +107,7 @@ export class PlungerHit extends HitObject {
 				isHit = true;
 				hitTime = newTime;
 				coll.set(hit);
-				coll.hitVel = new Vertex2D(0, 0);
+				coll.hitVel.set(0, 0);
 			}
 		}
 
@@ -167,7 +167,7 @@ export class PlungerHit extends HitObject {
 			isHit = true;
 			hitTime = newTime;
 			coll.set(hit);
-			coll.hitVel = new Vertex2D(0, deltaY);
+			coll.hitVel.set(0, deltaY);
 		}
 
 		for (let i = 0; i < 2; i++) {
@@ -176,7 +176,7 @@ export class PlungerHit extends HitObject {
 				isHit = true;
 				hitTime = newTime;
 				coll.set(hit);
-				coll.hitVel = new Vertex2D(0, deltaY);
+				coll.hitVel.set(0, deltaY);
 			}
 		}
 
@@ -237,7 +237,7 @@ export class PlungerHit extends HitObject {
 	public collide(coll: CollisionEvent, physics: PlayerPhysics): void {
 		const ball = coll.ball;
 
-		let dot = (ball.hit.vel.x - coll.hitVel!.x) * coll.hitNormal!.x + (ball.hit.vel.y - coll.hitVel!.y) * coll.hitNormal!.y;
+		let dot = (ball.hit.vel.x - coll.hitVel!.x) * coll.hitNormal.x + (ball.hit.vel.y - coll.hitVel!.y) * coll.hitNormal.y;
 		if (dot >= -C_LOWNORMVEL) {                        // nearly receding ... make sure of conditions
 			if (dot > C_LOWNORMVEL) {                      // otherwise if clearly approaching .. process the collision
 				return;                                    // is this velocity clearly receding (i.e must > a minimum)
@@ -260,7 +260,7 @@ export class PlungerHit extends HitObject {
 				hDist = C_DISP_LIMIT;
 			}                                              // crossing ramps, delta noise
 			// push along norm, back to free area (use the norm, but is not correct)
-			ball.state.pos.add(coll.hitNormal!.clone().multiplyScalar(hDist));
+			ball.state.pos.add(coll.hitNormal.clone().multiplyScalar(hDist));
 		}
 //#endif
 
@@ -299,7 +299,7 @@ export class PlungerHit extends HitObject {
 		}
 
 		// update the ball speed for the impulse
-		ball.hit.vel.add(coll.hitNormal!.clone().multiplyScalar(impulse));
+		ball.hit.vel.add(coll.hitNormal.clone().multiplyScalar(impulse));
 		ball.hit.vel.multiplyScalar(0.999);           //friction all axiz     //!! TODO: fix this
 
 		const scatterVel = this.mover.scatterVelocity; // fixme * g_pplayer->m_ptable->m_globalDifficulty;// apply dificulty weighting

--- a/lib/vpt/plunger/plunger-hit.ts
+++ b/lib/vpt/plunger/plunger-hit.ts
@@ -22,7 +22,7 @@ import { PlayerPhysics } from '../../game/player-physics';
 import { Vertex2D } from '../../math/vertex2d';
 import { CollisionEvent } from '../../physics/collision-event';
 import { C_DISP_GAIN, C_DISP_LIMIT, C_EMBEDDED, C_EMBEDSHOT, C_LOWNORMVEL } from '../../physics/constants';
-import { HitObject, HitTestResult } from '../../physics/hit-object';
+import { HitObject } from '../../physics/hit-object';
 import { Ball } from '../ball/ball';
 import { Table } from '../table/table';
 import { Plunger, PlungerConfig } from './plunger';
@@ -69,7 +69,7 @@ export class PlungerHit extends HitObject {
 		// zlow & zhigh gets set in constructor
 	}
 
-	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent, physics: PlayerPhysics): HitTestResult {
+	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent, physics: PlayerPhysics): number {
 
 		let hitTime = dTime; //start time
 		let isHit = false;
@@ -80,35 +80,33 @@ export class PlungerHit extends HitObject {
 		physics.lastPlungerHit = physics.timeMsec;
 
 		// We are close enable the plunger light.
-		let hit = new CollisionEvent(ball);
-		let newTime: number;
+		const hit = new CollisionEvent(ball);
 
 		// Check for hits on the non-moving parts, like the side of back
 		// of the plunger.  These are just like hitting a wall.
 		// Check all and find the nearest collision.
-
-		({ hitTime: newTime, coll: hit } = this.mover.lineSegBase.hitTest(ball, dTime, hit));
+		let newTime = this.mover.lineSegBase.hitTest(ball, dTime, hit);
 		if (newTime >= 0 && newTime <= hitTime) {
 			isHit = true;
 			hitTime = newTime;
-			coll = hit;
+			coll.set(hit);
 			coll.hitVel = new Vertex2D(0, 0);
 		}
 
 		for (let i = 0; i < 2; i++) {
-			({ hitTime: newTime, coll: hit } = this.mover.lineSegSide[i].hitTest(ball, hitTime, hit));
+			newTime = this.mover.lineSegSide[i].hitTest(ball, hitTime, hit);
 			if (newTime >= 0 && newTime <= hitTime) {
 				isHit = true;
 				hitTime = newTime;
-				coll = hit;
+				coll.set(hit);
 				coll.hitVel = new Vertex2D(0, 0);
 			}
 
-			({ hitTime: newTime, coll: hit } = this.mover.jointBase[i].hitTest(ball, hitTime, hit));
+			newTime = this.mover.jointBase[i].hitTest(ball, hitTime, hit);
 			if (newTime >= 0 && newTime <= hitTime) {
 				isHit = true;
 				hitTime = newTime;
-				coll = hit;
+				coll.set(hit);
 				coll.hitVel = new Vertex2D(0, 0);
 			}
 		}
@@ -164,20 +162,20 @@ export class PlungerHit extends HitObject {
 		const deltaY = this.mover.speed * xferRatio;
 
 		// check the moving bits
-		({ hitTime: newTime, coll: hit } = this.mover.lineSegEnd.hitTest(ball, hitTime, hit));
+		newTime = this.mover.lineSegEnd.hitTest(ball, hitTime, hit);
 		if (newTime >= 0 && newTime <= hitTime) {
 			isHit = true;
 			hitTime = newTime;
-			coll = hit;
+			coll.set(hit);
 			coll.hitVel = new Vertex2D(0, deltaY);
 		}
 
 		for (let i = 0; i < 2; i++) {
-			({ hitTime: newTime, coll: hit } = this.mover.jointEnd[i].hitTest(ball, hitTime, hit));
+			newTime = this.mover.jointEnd[i].hitTest(ball, hitTime, hit);
 			if (newTime >= 0 && newTime <= hitTime) {
 				isHit = true;
 				hitTime = newTime;
-				coll = hit;
+				coll.set(hit);
 				coll.hitVel = new Vertex2D(0, deltaY);
 			}
 		}
@@ -228,11 +226,11 @@ export class PlungerHit extends HitObject {
 			}
 
 			// return the collision time delta
-			return { hitTime, coll };
+			return hitTime;
 
 		} else {
 			// no collision
-			return { hitTime: -1.0, coll };
+			return -1.0;
 		}
 	}
 

--- a/lib/vpt/plunger/plunger-hit.ts
+++ b/lib/vpt/plunger/plunger-hit.ts
@@ -260,7 +260,7 @@ export class PlungerHit extends HitObject {
 				hDist = C_DISP_LIMIT;
 			}                                              // crossing ramps, delta noise
 			// push along norm, back to free area (use the norm, but is not correct)
-			ball.state.pos.add(coll.hitNormal.clone().multiplyScalar(hDist));
+			ball.state.pos.addAndRelease(coll.hitNormal.clone(true).multiplyScalar(hDist));
 		}
 //#endif
 
@@ -299,7 +299,7 @@ export class PlungerHit extends HitObject {
 		}
 
 		// update the ball speed for the impulse
-		ball.hit.vel.add(coll.hitNormal.clone().multiplyScalar(impulse));
+		ball.hit.vel.addAndRelease(coll.hitNormal.clone(true).multiplyScalar(impulse));
 		ball.hit.vel.multiplyScalar(0.999);           //friction all axiz     //!! TODO: fix this
 
 		const scatterVel = this.mover.scatterVelocity; // fixme * g_pplayer->m_ptable->m_globalDifficulty;// apply dificulty weighting

--- a/lib/vpt/plunger/plunger-hit.ts
+++ b/lib/vpt/plunger/plunger-hit.ts
@@ -182,6 +182,7 @@ export class PlungerHit extends HitObject {
 
 		// restore the original ball velocity (WARNING! CONST POINTER OVERRIDE!)
 		ball.hit.vel.y = oldVelY;
+		//CollisionEvent.release(hit);
 
 		// check for a hit
 		if (isHit) {

--- a/lib/vpt/plunger/plunger-hit.ts
+++ b/lib/vpt/plunger/plunger-hit.ts
@@ -182,7 +182,7 @@ export class PlungerHit extends HitObject {
 
 		// restore the original ball velocity (WARNING! CONST POINTER OVERRIDE!)
 		ball.hit.vel.y = oldVelY;
-		//CollisionEvent.release(hit);
+		CollisionEvent.release(hit);
 
 		// check for a hit
 		if (isHit) {

--- a/lib/vpt/plunger/plunger-hit.ts
+++ b/lib/vpt/plunger/plunger-hit.ts
@@ -80,7 +80,7 @@ export class PlungerHit extends HitObject {
 		physics.lastPlungerHit = physics.timeMsec;
 
 		// We are close enable the plunger light.
-		const hit = new CollisionEvent(ball);
+		const hit = CollisionEvent.claim(ball);
 
 		// Check for hits on the non-moving parts, like the side of back
 		// of the plunger.  These are just like hitting a wall.

--- a/lib/vpt/plunger/plunger-hit.ts
+++ b/lib/vpt/plunger/plunger-hit.ts
@@ -19,7 +19,6 @@
 
 import { EventProxy } from '../../game/event-proxy';
 import { PlayerPhysics } from '../../game/player-physics';
-import { Vertex2D } from '../../math/vertex2d';
 import { CollisionEvent } from '../../physics/collision-event';
 import { C_DISP_GAIN, C_DISP_LIMIT, C_EMBEDDED, C_EMBEDSHOT, C_LOWNORMVEL } from '../../physics/constants';
 import { HitObject } from '../../physics/hit-object';

--- a/lib/vpt/plunger/plunger-mesh-generator.ts
+++ b/lib/vpt/plunger/plunger-mesh-generator.ts
@@ -17,13 +17,13 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { Matrix3D } from '../../math/matrix3d';
 import { Vertex3DNoTex2 } from '../../math/vertex';
 import { Mesh } from '../mesh';
 import { Table } from '../table/table';
 import { PlungerType } from './plunger';
 import { PlungerData } from './plunger-data';
 import { PlungerDesc } from './plunger-desc';
-import { Matrix3D } from '../../math/matrix3d';
 
 const PLUNGER_FRAME_COUNT = 25;
 

--- a/lib/vpt/plunger/plunger-mesh-generator.ts
+++ b/lib/vpt/plunger/plunger-mesh-generator.ts
@@ -90,8 +90,6 @@ export class PlungerMeshGenerator {
 			return this.cache[frame];
 		}
 
-		console.log('Creating plunger mesh %s.', frame);
-
 		this.zHeight = table.getSurfaceHeight(this.data.szSurface, this.data.center.x, this.data.center.y) + this.data.zAdjust;
 		this.zScale = table.getScaleZ();
 		this.desc = this.getDesc();

--- a/lib/vpt/plunger/plunger-mover.spec.ts
+++ b/lib/vpt/plunger/plunger-mover.spec.ts
@@ -146,5 +146,5 @@ describe('The VPinball plunger physics', () => {
 
 function popState(player: Player, name: string): PlungerState {
 	const states = player.popStates();
-	return states[name].newState as PlungerState;
+	return states.getState<PlungerState>(name).newState;
 }

--- a/lib/vpt/plunger/plunger-state.ts
+++ b/lib/vpt/plunger/plunger-state.ts
@@ -17,18 +17,35 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { Pool } from '../../util/object-pool';
 import { ItemState } from '../item-state';
 
 export class PlungerState extends ItemState {
 
+	public static readonly POOL = new Pool(PlungerState);
+
 	/**
 	 * Which frame to render
 	 */
-	public frame: number;
+	public frame: number = 0;
 
-	constructor(name: string, frame: number) {
-		super(name);
-		this.frame = frame;
+	public constructor() {
+		super();
+	}
+
+	public static claim(name: string, frame: number): PlungerState {
+		const state = PlungerState.POOL.get();
+		state.name = name;
+		state.frame = frame;
+		return state;
+	}
+
+	public clone(): PlungerState {
+		return PlungerState.claim(this.name, this.frame);
+	}
+
+	public release(): void {
+		PlungerState.POOL.release(this);
 	}
 
 	public equals(state: PlungerState): boolean {
@@ -37,9 +54,5 @@ export class PlungerState extends ItemState {
 			return false;
 		}
 		return state.frame === this.frame;
-	}
-
-	public clone(): PlungerState {
-		return new PlungerState(this.name, this.frame);
 	}
 }

--- a/lib/vpt/plunger/plunger.ts
+++ b/lib/vpt/plunger/plunger.ts
@@ -27,7 +27,6 @@ import { IRenderable } from '../../game/irenderable';
 import { IScriptable } from '../../game/iscriptable';
 import { IBallCreationPosition, Player } from '../../game/player';
 import { PlayerPhysics } from '../../game/player-physics';
-import { Matrix3D } from '../../math/matrix3d';
 import { Vertex3D } from '../../math/vertex3d';
 import { HitObject } from '../../physics/hit-object';
 import { Ball } from '../ball/ball';

--- a/lib/vpt/plunger/plunger.ts
+++ b/lib/vpt/plunger/plunger.ts
@@ -63,7 +63,7 @@ export class Plunger implements IRenderable, IPlayable, IMovable<PlungerState>, 
 	public constructor(itemName: string, data: PlungerData) {
 		this.data = data;
 		this.mesh = new PlungerMesh(data);
-		this.state = new PlungerState(this.getName(), 0);
+		this.state = PlungerState.claim(this.getName(), 0);
 	}
 
 	public getName(): string {

--- a/lib/vpt/plunger/plunger.ts
+++ b/lib/vpt/plunger/plunger.ts
@@ -84,7 +84,7 @@ export class Plunger implements IRenderable, IPlayable, IMovable<PlungerState>, 
 		const material = table.getMaterial(this.data.szMaterial);
 		const map = table.getTexture(this.data.szImage);
 
-		const matrix = new Matrix3D().toRightHanded();
+		const matrix = Matrix3D.RIGHT_HANDED;
 
 		if (plunger.rod) {
 			meshes.rod = { mesh: plunger.rod.transform(matrix), material, map };
@@ -153,7 +153,7 @@ export class Plunger implements IRenderable, IPlayable, IMovable<PlungerState>, 
 
 	public applyState(obj: Object3D, table: Table): void {
 
-		const matrix = new Matrix3D().toRightHanded();
+		const matrix = Matrix3D.RIGHT_HANDED;
 		const mesh = this.mesh.generateMeshes(this.state.frame, table);
 
 		const rodObj = obj.children.find(o => o.name === 'rod') as any;

--- a/lib/vpt/primitive/primitive.ts
+++ b/lib/vpt/primitive/primitive.ts
@@ -75,7 +75,7 @@ export class Primitive implements IRenderable, IHittable, IScriptable<PrimitiveA
 	public getMeshes(table: Table): Meshes {
 		return {
 			primitive: {
-				mesh: this.getMesh(table).clone().transform(new Matrix3D().toRightHanded()),
+				mesh: this.getMesh(table).clone().transform(Matrix3D.RIGHT_HANDED),
 				map: table.getTexture(this.data.szImage),
 				normalMap: table.getTexture(this.data.szNormalMap),
 				material: table.getMaterial(this.data.szMaterial),

--- a/lib/vpt/ramp/ramp.ts
+++ b/lib/vpt/ramp/ramp.ts
@@ -99,45 +99,45 @@ export class Ramp implements IRenderable, IHittable {
 
 		if (ramp.wire1) {
 			meshes.wire1 = {
-				mesh: ramp.wire1.transform(new Matrix3D().toRightHanded()),
+				mesh: ramp.wire1.transform(Matrix3D.RIGHT_HANDED),
 				material: table.getMaterial(this.data.szMaterial),
 			};
 		}
 		if (ramp.wire2) {
 			meshes.wire2 = {
-				mesh: ramp.wire2.transform(new Matrix3D().toRightHanded()),
+				mesh: ramp.wire2.transform(Matrix3D.RIGHT_HANDED),
 				material: table.getMaterial(this.data.szMaterial),
 			};
 		}
 		if (ramp.wire3) {
 			meshes.wire3 = {
-				mesh: ramp.wire3.transform(new Matrix3D().toRightHanded()),
+				mesh: ramp.wire3.transform(Matrix3D.RIGHT_HANDED),
 				material: table.getMaterial(this.data.szMaterial),
 			};
 		}
 		if (ramp.wire4) {
 			meshes.wire4 = {
-				mesh: ramp.wire4.transform(new Matrix3D().toRightHanded()),
+				mesh: ramp.wire4.transform(Matrix3D.RIGHT_HANDED),
 				material: table.getMaterial(this.data.szMaterial),
 			};
 		}
 		if (ramp.floor) {
 			meshes.floor = {
-				mesh: ramp.floor.transform(new Matrix3D().toRightHanded()),
+				mesh: ramp.floor.transform(Matrix3D.RIGHT_HANDED),
 				material: table.getMaterial(this.data.szMaterial),
 				map: table.getTexture(this.data.szImage),
 			};
 		}
 		if (ramp.left) {
 			meshes.left = {
-				mesh: ramp.left.transform(new Matrix3D().toRightHanded()),
+				mesh: ramp.left.transform(Matrix3D.RIGHT_HANDED),
 				material: table.getMaterial(this.data.szMaterial),
 				map: table.getTexture(this.data.szImage),
 			};
 		}
 		if (ramp.right) {
 			meshes.right = {
-				mesh: ramp.right.transform(new Matrix3D().toRightHanded()),
+				mesh: ramp.right.transform(Matrix3D.RIGHT_HANDED),
 				material: table.getMaterial(this.data.szMaterial),
 				map: table.getTexture(this.data.szImage),
 			};

--- a/lib/vpt/rubber/rubber-mesh-generator.ts
+++ b/lib/vpt/rubber/rubber-mesh-generator.ts
@@ -80,7 +80,6 @@ export class RubberMeshGenerator {
 		for (let i = 0; i < numRings; i++) {
 
 			const i2 = (i === numRings - 1) ? 0 : i + 1;
-
 			const tangent = new Vertex3D(sv.pMiddlePoints[i2].x - sv.pMiddlePoints[i].x, sv.pMiddlePoints[i2].y - sv.pMiddlePoints[i].y, 0.0);
 
 			let binorm: Vertex3D;

--- a/lib/vpt/rubber/rubber.ts
+++ b/lib/vpt/rubber/rubber.ts
@@ -71,7 +71,7 @@ export class Rubber implements IRenderable, IHittable {
 		const mesh = this.meshGenerator.getMeshes(table);
 		return {
 			rubber: {
-				mesh: mesh.transform(new Matrix3D().toRightHanded()),
+				mesh: mesh.transform(Matrix3D.RIGHT_HANDED),
 				map: table.getTexture(this.data.szImage),
 				material: table.getMaterial(this.data.szMaterial),
 			},

--- a/lib/vpt/spinner/spinner-hit.ts
+++ b/lib/vpt/spinner/spinner-hit.ts
@@ -92,7 +92,7 @@ export class SpinnerHit extends HitObject {
 
 	public collide(coll: CollisionEvent, physics: PlayerPhysics): void {
 
-		const dot = coll.hitNormal!.dot(coll.ball.hit.vel);
+		const dot = coll.hitNormal.dot(coll.ball.hit.vel);
 		if (dot < 0) {                                     // hit from back doesn't count
 			return;
 		}

--- a/lib/vpt/spinner/spinner-hit.ts
+++ b/lib/vpt/spinner/spinner-hit.ts
@@ -25,7 +25,7 @@ import { Vertex2D } from '../../math/vertex2d';
 import { CollisionEvent } from '../../physics/collision-event';
 import { CollisionType } from '../../physics/collision-type';
 import { PHYS_SKIN } from '../../physics/constants';
-import { HitObject, HitTestResult } from '../../physics/hit-object';
+import { HitObject } from '../../physics/hit-object';
 import { LineSeg } from '../../physics/line-seg';
 import { Ball } from '../ball/ball';
 import { SpinnerData } from './spinner-data';
@@ -75,20 +75,19 @@ export class SpinnerHit extends HitObject {
 		this.hitBBox = this.lineSegs[0].hitBBox;
 	}
 
-	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent, physics: PlayerPhysics): HitTestResult {
+	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent, physics: PlayerPhysics): number {
 		if (!this.isEnabled) {
-			return { hitTime: -1.0, coll };
+			return -1.0;
 		}
 		for (let i = 0; i < 2; ++i) {
-			let hitTime: number;
-			({ hitTime, coll } = this.lineSegs[i].hitTestBasic(ball, dTime, coll, false, true, false)); // any face, lateral, non-rigid
+			const hitTime = this.lineSegs[i].hitTestBasic(ball, dTime, coll, false, true, false); // any face, lateral, non-rigid
 			if (hitTime >= 0) {
 				// signal the Collide() function that the hit is on the front or back side
 				coll.hitFlag = !i;
-				return { hitTime, coll };
+				return hitTime;
 			}
 		}
-		return { hitTime: -1.0, coll };
+		return -1.0;
 	}
 
 	public collide(coll: CollisionEvent, physics: PlayerPhysics): void {

--- a/lib/vpt/spinner/spinner-mesh-generator.ts
+++ b/lib/vpt/spinner/spinner-mesh-generator.ts
@@ -65,17 +65,17 @@ export class SpinnerMeshGenerator {
 	private updateVertices(table: Table, posZ: number, mesh: Mesh): Mesh {
 		const matrix = new Matrix3D().rotateZMatrix(degToRad(this.data.rotation));
 		for (const vertex of mesh.vertices) {
-			let vert = new Vertex3D(vertex.x, vertex.y, vertex.z);
-			vert = matrix.multiplyVector(vert);
+			const vert = Vertex3D.claim(vertex.x, vertex.y, vertex.z).multiplyMatrix(matrix);
 			vertex.x = f4(vert.x * this.data.length) + this.data.vCenter.x;
 			vertex.y = f4(vert.y * this.data.length) + this.data.vCenter.y;
 			vertex.z = f4(f4(vert.z * this.data.length) * table.getScaleZ()) + posZ;
 
-			let norm = new Vertex3D(vertex.nx, vertex.ny, vertex.nz);
-			norm = matrix.multiplyVectorNoTranslate(norm);
-			vertex.nx = norm.x;
-			vertex.ny = norm.y;
-			vertex.nz = norm.z;
+			const normal = Vertex3D.claim(vertex.nx, vertex.ny, vertex.nz).multiplyMatrixNoTranslate(matrix);
+			vertex.nx = normal.x;
+			vertex.ny = normal.y;
+			vertex.nz = normal.z;
+
+			Vertex3D.release(vert, normal);
 		}
 		return mesh;
 	}

--- a/lib/vpt/spinner/spinner-mover.spec.ts
+++ b/lib/vpt/spinner/spinner-mover.spec.ts
@@ -103,7 +103,7 @@ describe('The VPinball spinner collision', () => {
 		player.updatePhysics(0);
 		player.updatePhysics(160);
 
-		const state = player.popStates().Transformed.newState as SpinnerState;
+		const state = player.popStates().getState<SpinnerState>('Transformed').newState;
 		expect(state.angle).to.equal(spinner.getState().angle);
 	});
 

--- a/lib/vpt/spinner/spinner-state.ts
+++ b/lib/vpt/spinner/spinner-state.ts
@@ -17,18 +17,35 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { Pool } from '../../util/object-pool';
 import { ItemState } from '../item-state';
 
 export class SpinnerState extends ItemState {
 
+	public static readonly POOL = new Pool(SpinnerState);
+
 	/**
 	 * Angle in rad
 	 */
-	public angle: number;
+	public angle: number = 0;
 
-	constructor(name: string, angle: number) {
-		super(name);
-		this.angle = angle;
+	public constructor() {
+		super();
+	}
+
+	public static claim(name: string, angle: number): SpinnerState {
+		const state = SpinnerState.POOL.get();
+		state.name = name;
+		state.angle = angle;
+		return state;
+	}
+
+	public clone(): SpinnerState {
+		return SpinnerState.claim(this.name, this.angle);
+	}
+
+	public release(): void {
+		SpinnerState.POOL.release(this);
 	}
 
 	public equals(state: SpinnerState): boolean {
@@ -37,9 +54,5 @@ export class SpinnerState extends ItemState {
 			return false;
 		}
 		return state.angle === this.angle;
-	}
-
-	public clone(): SpinnerState {
-		return new SpinnerState(this.name, this.angle);
 	}
 }

--- a/lib/vpt/spinner/spinner.ts
+++ b/lib/vpt/spinner/spinner.ts
@@ -128,11 +128,11 @@ export class Spinner implements IRenderable, IPlayable, IMovable<FlipperState>, 
 	public applyState(obj: Object3D, table: Table, player: Player): void {
 
 		const posZ = this.meshGenerator.getZ(table);
-		const matTransToOrigin = new Matrix3D().setTranslation(-this.data.vCenter.x, -this.data.vCenter.y, posZ);
-		const matRotateToOrigin = new Matrix3D().rotateZMatrix(degToRad(-this.data.rotation));
-		const matTransFromOrigin = new Matrix3D().setTranslation(this.data.vCenter.x, this.data.vCenter.y, -posZ);
-		const matRotateFromOrigin = new Matrix3D().rotateZMatrix(degToRad(this.data.rotation));
-		const matRotateX = new Matrix3D().rotateXMatrix(this.state.angle - degToRad(this.data.angleMin));
+		const matTransToOrigin = Matrix3D.claim().setTranslation(-this.data.vCenter.x, -this.data.vCenter.y, posZ);
+		const matRotateToOrigin = Matrix3D.claim().rotateZMatrix(degToRad(-this.data.rotation));
+		const matTransFromOrigin = Matrix3D.claim().setTranslation(this.data.vCenter.x, this.data.vCenter.y, -posZ);
+		const matRotateFromOrigin = Matrix3D.claim().rotateZMatrix(degToRad(this.data.rotation));
+		const matRotateX = Matrix3D.claim().rotateXMatrix(this.state.angle - degToRad(this.data.angleMin));
 
 		const matrix = matTransToOrigin
 			.multiply(matRotateToOrigin)
@@ -141,10 +141,8 @@ export class Spinner implements IRenderable, IPlayable, IMovable<FlipperState>, 
 			.multiply(matTransFromOrigin);
 
 		const plateObj = obj.children.find(c => c.name === `spinner.plate-${this.getName()}`)!;
-		plateObj.matrix = matrix.toThreeMatrix4();
-		plateObj.matrixWorldNeedsUpdate = true;
+		matrix.applyToObject3D(plateObj);
 
-		//console.log('new spinner state: ', degToRad(this.state.angle));
+		Matrix3D.release(matTransToOrigin, matRotateToOrigin, matTransFromOrigin, matRotateFromOrigin, matRotateX);
 	}
-
 }

--- a/lib/vpt/spinner/spinner.ts
+++ b/lib/vpt/spinner/spinner.ts
@@ -65,7 +65,7 @@ export class Spinner implements IRenderable, IPlayable, IMovable<FlipperState>, 
 
 	constructor(data: SpinnerData) {
 		this.data = data;
-		this.state = new SpinnerState(this.data.getName(), 0);
+		this.state = SpinnerState.claim(this.data.getName(), 0);
 		this.meshGenerator = new SpinnerMeshGenerator(data);
 		this.hitGenerator = new SpinnerHitGenerator(data);
 	}

--- a/lib/vpt/spinner/spinner.ts
+++ b/lib/vpt/spinner/spinner.ts
@@ -87,13 +87,13 @@ export class Spinner implements IRenderable, IPlayable, IMovable<FlipperState>, 
 		const meshes: Meshes = {};
 
 		meshes.plate = {
-			mesh: spinner.plate.transform(new Matrix3D().toRightHanded()),
+			mesh: spinner.plate.transform(Matrix3D.RIGHT_HANDED),
 			map: table.getTexture(this.data.szImage),
 			material: table.getMaterial(this.data.szMaterial),
 		};
 		if (spinner.bracket) {
 			meshes.bracket = {
-				mesh: spinner.bracket.transform(new Matrix3D().toRightHanded()),
+				mesh: spinner.bracket.transform(Matrix3D.RIGHT_HANDED),
 				map: table.getTexture(this.data.szImage),
 				material: table.getMaterial(this.data.szMaterial),
 			};

--- a/lib/vpt/surface/surface.ts
+++ b/lib/vpt/surface/surface.ts
@@ -109,7 +109,7 @@ export class Surface implements IRenderable, IHittable, IScriptable<SurfaceApi> 
 		const surface = this.meshGenerator.generateMeshes(this.data, table);
 		if (surface.top) {
 			meshes.top = {
-				mesh: surface.top.transform(new Matrix3D().toRightHanded()),
+				mesh: surface.top.transform(Matrix3D.RIGHT_HANDED),
 				map: table.getTexture(this.data.szImage),
 				material: table.getMaterial(this.data.szTopMaterial),
 			};
@@ -117,7 +117,7 @@ export class Surface implements IRenderable, IHittable, IScriptable<SurfaceApi> 
 
 		if (surface.side) {
 			meshes.side = {
-				mesh: surface.side.transform(new Matrix3D().toRightHanded()),
+				mesh: surface.side.transform(Matrix3D.RIGHT_HANDED),
 				map: table.getTexture(this.data.szSideImage),
 				material: table.getMaterial(this.data.szSideMaterial),
 			};

--- a/lib/vpt/trigger/trigger-hit-circle.ts
+++ b/lib/vpt/trigger/trigger-hit-circle.ts
@@ -55,7 +55,7 @@ export class TriggerHitCircle extends HitCircle {
 
 		const i = ball.hit.vpVolObjs.indexOf(this.obj!);                         // if -1 then not in objects volume set (i.e not already hit)
 		if (coll.hitFlag !== i < 0) {                                            // Hit == NotAlreadyHit
-			ball.state.pos.add(ball.hit.vel.clone().multiplyScalar(STATICTIME)); // move ball slightly forward
+			ball.state.pos.addAndRelease(ball.hit.vel.clone(true).multiplyScalar(STATICTIME)); // move ball slightly forward
 
 			if (i < 0) {
 				ball.hit.vpVolObjs.push(this.obj!);

--- a/lib/vpt/trigger/trigger-hit-circle.ts
+++ b/lib/vpt/trigger/trigger-hit-circle.ts
@@ -24,7 +24,6 @@ import { CollisionEvent } from '../../physics/collision-event';
 import { CollisionType } from '../../physics/collision-type';
 import { STATICTIME } from '../../physics/constants';
 import { HitCircle } from '../../physics/hit-circle';
-import { HitTestResult } from '../../physics/hit-object';
 import { Ball } from '../ball/ball';
 import { Table } from '../table/table';
 import { TriggerAnimation } from './trigger-animation';
@@ -42,7 +41,7 @@ export class TriggerHitCircle extends HitCircle {
 		this.obj = events;
 	}
 
-	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent): HitTestResult {
+	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent): number {
 		// any face, not-lateral, non-rigid
 		return super.hitTestBasicRadius(ball, dTime, coll, false, false, false);
 	}

--- a/lib/vpt/trigger/trigger-hit.spec.ts
+++ b/lib/vpt/trigger/trigger-hit.spec.ts
@@ -101,7 +101,7 @@ describe('The VPinball trigger collision', () => {
 		// let it roll onto trigger
 		player.updatePhysics(0);
 		player.updatePhysics(900);
-		const state = player.popStates().WireB.newState as TriggerState;
+		const state = player.popStates().getState<TriggerState>('WireB').newState;
 		expect(state.heightOffset).to.equal(trigger.getState().heightOffset);
 	});
 

--- a/lib/vpt/trigger/trigger-line-seg.ts
+++ b/lib/vpt/trigger/trigger-line-seg.ts
@@ -22,7 +22,6 @@ import { Vertex2D } from '../../math/vertex2d';
 import { CollisionEvent } from '../../physics/collision-event';
 import { CollisionType } from '../../physics/collision-type';
 import { STATICTIME } from '../../physics/constants';
-import { HitTestResult } from '../../physics/hit-object';
 import { LineSeg } from '../../physics/line-seg';
 import { Ball } from '../ball/ball';
 import { TriggerAnimation } from './trigger-animation';
@@ -40,9 +39,9 @@ export class TriggerLineSeg extends LineSeg {
 		this.objType = CollisionType.Trigger;
 	}
 
-	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent): HitTestResult {
+	public hitTest(ball: Ball, dTime: number, coll: CollisionEvent): number {
 		if (!this.data.isEnabled) {
-			return { hitTime: -1.0, coll };
+			return -1.0;
 		}
 
 		// approach either face, not lateral-rolling point (assume center), not a rigid body contact

--- a/lib/vpt/trigger/trigger-line-seg.ts
+++ b/lib/vpt/trigger/trigger-line-seg.ts
@@ -59,7 +59,7 @@ export class TriggerLineSeg extends LineSeg {
 
 		// if -1 then not in objects volume set (i.e not already hit)
 		if (coll.hitFlag !== i < 0) {                                             // Hit == NotAlreadyHit
-			ball.state.pos.add(ball.hit.vel.clone().multiplyScalar(STATICTIME));  // move ball slightly forward
+			ball.state.pos.addAndRelease(ball.hit.vel.clone(true).multiplyScalar(STATICTIME));  // move ball slightly forward
 
 			if (i < 0) {
 				ball.hit.vpVolObjs.push(this.obj!);

--- a/lib/vpt/trigger/trigger-mesh-generator.ts
+++ b/lib/vpt/trigger/trigger-mesh-generator.ts
@@ -66,8 +66,8 @@ export class TriggerMeshGenerator {
 		const mesh = this.getBaseMesh();
 		for (const vertex of mesh.vertices) {
 
-			let vert = new Vertex3D(vertex.x, vertex.y, vertex.z);
-			vert = fullMatrix.multiplyVector(vert);
+			const vert = Vertex3D.claim(vertex.x, vertex.y, vertex.z).multiplyMatrix(fullMatrix);
+			//fullMatrix.multiplyVector(vert);
 
 			if (this.data.shape === Trigger.ShapeTriggerButton || this.data.shape === Trigger.ShapeTriggerStar) {
 				vertex.x = f4(vert.x * this.data.radius) + this.data.vCenter.x;
@@ -79,11 +79,12 @@ export class TriggerMeshGenerator {
 				vertex.z = f4(f4(vert.z * table.getScaleZ()) + baseHeight) + zOffset;
 			}
 
-			vert = new Vertex3D(vertex.nx, vertex.ny, vertex.nz);
-			vert = fullMatrix.multiplyVectorNoTranslate(vert);
-			vertex.nx = vert.x;
-			vertex.ny = vert.y;
-			vertex.nz = vert.z;
+			const normal = Vertex3D.claim(vertex.nx, vertex.ny, vertex.nz).multiplyMatrixNoTranslate(fullMatrix);
+			vertex.nx = normal.x;
+			vertex.ny = normal.y;
+			vertex.nz = normal.z;
+
+			Vertex3D.release(vert, normal);
 		}
 		return mesh;
 	}

--- a/lib/vpt/trigger/trigger-state.ts
+++ b/lib/vpt/trigger/trigger-state.ts
@@ -17,15 +17,32 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { Pool } from '../../util/object-pool';
 import { ItemState } from '../item-state';
 
 export class TriggerState extends ItemState {
 
-	public heightOffset: number;
+	public static readonly POOL = new Pool(TriggerState);
 
-	constructor(name: string, heightOffset: number = 0) {
-		super(name);
-		this.heightOffset = heightOffset;
+	public heightOffset: number = 0;
+
+	public constructor() {
+		super();
+	}
+
+	public static claim(name: string, heightOffset: number): TriggerState {
+		const state = TriggerState.POOL.get();
+		state.name = name;
+		state.heightOffset = heightOffset;
+		return state;
+	}
+
+	public clone(): TriggerState {
+		return TriggerState.claim(this.name, this.heightOffset);
+	}
+
+	public release(): void {
+		TriggerState.POOL.release(this);
 	}
 
 	public equals(state: TriggerState): boolean {
@@ -34,9 +51,5 @@ export class TriggerState extends ItemState {
 			return false;
 		}
 		return state.heightOffset === this.heightOffset;
-	}
-
-	public clone(): TriggerState {
-		return new TriggerState(this.name, this.heightOffset);
 	}
 }

--- a/lib/vpt/trigger/trigger.ts
+++ b/lib/vpt/trigger/trigger.ts
@@ -97,7 +97,7 @@ export class Trigger implements IRenderable, IHittable, IAnimatable<TriggerState
 	public getMeshes(table: Table): Meshes {
 		return {
 			trigger: {
-				mesh: this.meshGenerator.getMesh(table).transform(new Matrix3D().toRightHanded()),
+				mesh: this.meshGenerator.getMesh(table).transform(Matrix3D.RIGHT_HANDED),
 				material: table.getMaterial(this.data.szMaterial),
 			},
 		};

--- a/lib/vpt/trigger/trigger.ts
+++ b/lib/vpt/trigger/trigger.ts
@@ -128,9 +128,9 @@ export class Trigger implements IRenderable, IHittable, IAnimatable<TriggerState
 	}
 
 	public applyState(obj: Object3D, table: Table, player: Player): void {
-		const matrix = new Matrix3D().setTranslation(0, 0, -this.state.heightOffset);
-		obj.matrix = matrix.toThreeMatrix4();
-		obj.matrixWorldNeedsUpdate = true;
+		const matrix = Matrix3D.claim().setTranslation(0, 0, -this.state.heightOffset);
+		matrix.applyToObject3D(obj);
+		Matrix3D.release(matrix);
 	}
 
 	public getEventNames(): string[] {

--- a/lib/vpt/trigger/trigger.ts
+++ b/lib/vpt/trigger/trigger.ts
@@ -69,7 +69,7 @@ export class Trigger implements IRenderable, IHittable, IAnimatable<TriggerState
 
 	private constructor(data: TriggerData) {
 		this.data = data;
-		this.state = new TriggerState(data.getName(), 0);
+		this.state = TriggerState.claim(data.getName(), 0);
 		this.meshGenerator = new TriggerMeshGenerator(data);
 		this.hitGenerator = new TriggerHitGenerator(data);
 	}


### PR DESCRIPTION
This PR aims to lower memory consumption of the game loop as well as keep the garbage collector's work to a minimum in order to avoid micro stutters.

Given JavaScript is a managed language, we can't decide when an instantiated object is freed once it's not used anymore. Garbage collection block the event loop and result in undesired stutters. Until now, the physics loop instantiated ten thousands of objects per second, resulting in the GC being busy with cleaning up.

This PR adds an implementation of object pools, where for a given class, a small number of objects is being kept in memory, provided when a new instance is needed and returned when usage is completed. This results in very few objects being created (typically <10 per second), while before it could go easily over 20k objects.

Here's a performance timeline from before:

![image](https://user-images.githubusercontent.com/70426/64480020-629ea180-d1c0-11e9-9d62-d6741b45ad06.png)

And here the same table, afterwards:

![image](https://user-images.githubusercontent.com/70426/64480026-6f22fa00-d1c0-11e9-9c0d-e8b9e394ea2d.png)

Note the JS heap varying only a few megs compared to nearly 50mb before. Also the overall memory consumption is down to half as much. And lastly, something seems to have leaked before!

However there are still spikes and that's still up to investigation. In order to measure object instantiation, I've written a Webpack loader that wraps object, class and array instantiations into a function that logs and counts. For more info see freezy/vpweb#4.

### References

- [High-Performance, Garbage-Collector-Friendly Code](http://buildnewgames.com/garbage-collector-friendly-code/) (2012)
- [Static Memory Javascript with Object Pools](https://www.html5rocks.com/en/tutorials/speed/static-mem-pools/) (2013)