### PR TITLE
Hoist functions to the top

### DIFF
--- a/lib/scripting/transformer/function-hoist-transformer.spec.ts
+++ b/lib/scripting/transformer/function-hoist-transformer.spec.ts
@@ -23,12 +23,12 @@ import { astToVbs, vbsToAst } from '../../../test/script.helper';
 import { TableBuilder } from '../../../test/table-builder';
 import { Player } from '../../game/player';
 import { Table } from '../../vpt/table/table';
-import { CleanupTransformer } from './cleanup-transformer';
+import { FunctionHoistTransformer } from './function-hoist-transformer';
 
 chai.use(require('sinon-chai'));
 
 /* tslint:disable:no-unused-expression */
-describe('The scripting cleanup transformer', () => {
+describe('The scripting function hoist transformer', () => {
 
 	let table: Table;
 	let player: Player;
@@ -38,16 +38,16 @@ describe('The scripting cleanup transformer', () => {
 		player = new Player(table);
 	});
 
-	it('should not render any comments', () => {
-		const vbs = `' this is a comment\ndim test\n`;
+	it('should move a function to the top', () => {
+		const vbs = `test\nsub test\nend sub`;
 		const js = transform(vbs);
-		expect(js).to.equal(`let test;`);
+		expect(js).to.equal(`function test() {\n}\ntest();`);
 	});
 
 });
 
 function transform(vbs: string): string {
 	const ast = vbsToAst(vbs);
-	const eventAst = new CleanupTransformer(ast).transform();
+	const eventAst = new FunctionHoistTransformer(ast).transform();
 	return astToVbs(eventAst);
 }

--- a/lib/scripting/transformer/function-hoist-transformer.ts
+++ b/lib/scripting/transformer/function-hoist-transformer.ts
@@ -1,0 +1,48 @@
+/*
+ * VPDB - Virtual Pinball Database
+ * Copyright (C) 2019 freezy <freezy@vpdb.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { Program } from 'estree';
+import { Transformer } from './transformer';
+
+/**
+ * Since function declarations are converted to expressions, we need to declare
+ * before we use them.
+ *
+ * This hoists all function declarations of the root body to the top.
+ */
+export class FunctionHoistTransformer extends Transformer {
+
+	constructor(ast: Program) {
+		super(ast);
+	}
+
+	public transform(): Program {
+		const functions: any[] = [];
+		const others: any[] = [];
+		for (const node of this.ast.body) {
+			if (node.type === 'FunctionDeclaration') {
+				functions.push(node);
+			} else {
+				others.push(node);
+			}
+		}
+		this.ast.body = functions.concat(...others);
+		return this.ast;
+	}
+}

--- a/lib/scripting/transpiler.ts
+++ b/lib/scripting/transpiler.ts
@@ -29,6 +29,7 @@ import { Stdlib } from './stdlib';
 import { AmbiguityTransformer } from './transformer/ambiguity-transformer';
 import { CleanupTransformer } from './transformer/cleanup-transformer';
 import { EventTransformer } from './transformer/event-transformer';
+import { FunctionHoistTransformer } from './transformer/function-hoist-transformer';
 import { ReferenceTransformer } from './transformer/reference-transformer';
 import { ScopeTransformer } from './transformer/scope-transformer';
 import { WrapTransformer } from './transformer/wrap-transformer';
@@ -58,16 +59,18 @@ export class Transpiler {
 
 	public transpile(vbs: string, globalFunction?: string, globalObject?: string) {
 
-		logger().debug(vbs);
+		//logger().debug(vbs);
 		let ast = this.parse(vbs + '\n');
+
 		ast = new CleanupTransformer(ast).transform();
+		ast = new FunctionHoistTransformer(ast).transform();
 		ast = new EventTransformer(ast, this.table.getElements()).transform();
 		ast = new ReferenceTransformer(ast, this.table, this.itemApis, this.enumApis, this.globalApi, this.stdlib).transform();
 		ast = new ScopeTransformer(ast).transform();
 		ast = new AmbiguityTransformer(ast, this.itemApis, this.enumApis, this.globalApi, this.stdlib).transform();
 		ast = new WrapTransformer(ast).transform(globalFunction, globalObject);
-
 		logger().debug('AST:', ast);
+
 		const js = this.generate(ast);
 		logger().debug(js);
 


### PR DESCRIPTION
This PR moves root function declarations to the top of the tree. Closes #117.