### PR TITLE
Update getOrCall to support multi-dimension arrays and multi param functions

### DIFF
--- a/lib/scripting/post-process/helpers.ts
+++ b/lib/scripting/post-process/helpers.ts
@@ -319,12 +319,12 @@ export function id(result: [Token]): Identifier {
 	return estree.identifier(name);
 }
 
-export function getOrCall(callee: Expression, arg?: Expression): CallExpression {
+export function getOrCall(callee: Expression, ...args: Expression[]): CallExpression {
 	return estree.callExpression(
 		estree.memberExpression(
 			estree.identifier(Transformer.VBSHELPER_NAME),
 			estree.identifier('getOrCall'),
 		),
-		arg ? [ callee, arg ] : [ callee ],
+		[ callee, ...args ],
 	);
 }

--- a/lib/scripting/post-process/helpers.ts
+++ b/lib/scripting/post-process/helpers.ts
@@ -318,13 +318,3 @@ export function id(result: [Token]): Identifier {
 	}
 	return estree.identifier(name);
 }
-
-export function getOrCall(callee: Expression, ...args: Expression[]): CallExpression {
-	return estree.callExpression(
-		estree.memberExpression(
-			estree.identifier(Transformer.VBSHELPER_NAME),
-			estree.identifier('getOrCall'),
-		),
-		[ callee, ...args ],
-	);
-}

--- a/lib/scripting/transformer/ambiguity-transformer.spec.ts
+++ b/lib/scripting/transformer/ambiguity-transformer.spec.ts
@@ -73,6 +73,18 @@ describe('The scripting ambiguity transformer', () => {
 				`${Transformer.SCOPE_NAME}.x = ${Transformer.VBSHELPER_NAME}.getOrCall(${Transformer.SCOPE_NAME}.DOFeffects, ${Transformer.SCOPE_NAME}.Effect);`,
 			);
 		});
+
+		it('should handle multi-dim arrays', () => {
+			const vbs = `dim result(1, 1, 1)\nresult(0, 0, 0) = 42`;
+			const js = transpiler.transpile(vbs);
+			expect(js).to.equal(`__scope.result = __vbsHelper.dim([\n    1,\n    1,\n    1\n]);\n__scope.result[0][0][0] = 42;`);
+		});
+
+		it('should pass the function and not the name to the helper', () => {
+			const vbs = `result = My.Fct(10, 2)`;
+			const js = transpiler.transpile(vbs);
+			expect(js).to.equal(`__scope.result = __vbsHelper.getOrCall(__scope.My.Function, 10, 2);`);
+		});
 	});
 
 	describe('with an ambiguous property', () => {

--- a/lib/scripting/transformer/ambiguity-transformer.ts
+++ b/lib/scripting/transformer/ambiguity-transformer.ts
@@ -18,11 +18,10 @@
  */
 
 import { replace } from 'estraverse';
-import { Expression, MemberExpression, Program } from 'estree';
+import { CallExpression, Expression, MemberExpression, Program } from 'estree';
 import { EnumsApi } from '../../vpt/enums';
 import { GlobalApi } from '../../vpt/global-api';
-import { callExpression, memberExpression } from '../estree';
-import { getOrCall } from '../post-process/helpers';
+import { callExpression, identifier, memberExpression } from '../estree';
 import { Stdlib } from '../stdlib';
 import { Transformer } from './transformer';
 
@@ -207,4 +206,19 @@ function getValue(obj: any, ast: MemberExpression, path: string[] = []): any {
 		return o;
 	}
 	return undefined;
+}
+
+/**
+ * Creates a callExpression to the "getOrCall" vbs-helper.
+ * @param callee Object
+ * @param ...args Arguments
+ */
+function getOrCall(callee: Expression, ...args: Expression[]): CallExpression {
+	return callExpression(
+		memberExpression(
+			identifier(Transformer.VBSHELPER_NAME),
+			identifier('getOrCall'),
+		),
+		[ callee, ...args ],
+	);
 }

--- a/lib/scripting/transformer/ambiguity-transformer.ts
+++ b/lib/scripting/transformer/ambiguity-transformer.ts
@@ -110,7 +110,7 @@ export class AmbiguityTransformer extends Transformer {
 					}
 
 					// otherwise, we don't know, so use getOrCall
-					return getOrCall(node.callee as Expression, node.arguments[0] as Expression);
+					return getOrCall(node.callee as Expression, ...node.arguments as Expression[]);
 				}
 				return node;
 			},

--- a/lib/scripting/transformer/ambiguity-transformer.ts
+++ b/lib/scripting/transformer/ambiguity-transformer.ts
@@ -87,12 +87,15 @@ export class AmbiguityTransformer extends Transformer {
 
 					// if it's an assignment where its left is the node, it's definitely not a function call
 					if (parent && parent.type === 'AssignmentExpression' && node === parent.left) {
-						const arrayNode = memberExpression(
-							node.callee,
-							node.arguments[0] as Expression,
-							true,
-						) as any;
-						arrayNode.__isProperty = true;
+						let arrayNode: any = null;
+						for (const argument of node.arguments) {
+							arrayNode = memberExpression(
+								arrayNode !== null ? arrayNode : node.callee,
+								argument as Expression,
+								true) as any;
+
+							arrayNode.__isProperty = true;
+						}
 						return arrayNode;
 					}
 

--- a/lib/scripting/transformer/ambiguity-transformer.ts
+++ b/lib/scripting/transformer/ambiguity-transformer.ts
@@ -73,14 +73,11 @@ export class AmbiguityTransformer extends Transformer {
 			enter: (node, parent: any) => {
 				if (node.type === 'CallExpression') {
 
-					// if there's more than one argument, it's definitely a function
-					if (!node.arguments || node.arguments.length !== 1) {
-						return node;
-					}
-
-					// if the parameter is a string, it's not an array index
-					if (node.arguments[0].type === 'Literal' && typeof node.arguments[0].value === 'string') {
-						return node;
+					// if any of the parameters are a string, it's not an array index
+					for (const argument of node.arguments) {
+						if (argument.type === 'Literal' && typeof argument.value === 'string') {
+							return node;
+						}
 					}
 
 					// we know what `eval()` is..

--- a/lib/scripting/vbs-helper.spec.ts
+++ b/lib/scripting/vbs-helper.spec.ts
@@ -140,4 +140,35 @@ describe('The scripting VBS Helper', () => {
 			}
 		}
 	});
+
+	it('should get a value in a single-dimension array using "getOrCall"', () => {
+		const js = vbsHelper.dim([20]);
+		js[20] = 'Test';
+		const value = vbsHelper.getOrCall(js, 20);
+		expect(js[20]).to.equal(`Test`);
+	});
+
+	it('should get a value in a three-dimension array using "getOrCall"', () => {
+		const js = vbsHelper.dim([2, 2, 3]);
+		js[0][0][3] = 'Test';
+		const value = vbsHelper.getOrCall(js, 0, 0, 3);
+		expect(value).to.equal(`Test`);
+	});
+
+	it('should get the return value of a function using "getOrCall" and no params', () => {
+		const js = () => {
+			return 'Test';
+		};
+		const value = vbsHelper.getOrCall(js);
+		expect(value).to.equal(`Test`);
+	});
+
+	it('should get the return value of a function using "getOrCall" and multiple params', () => {
+		const js = (value1: number, value2: number, value3: number) => {
+			return value1 + value2 + value3;
+		};
+		const value = vbsHelper.getOrCall(js, 8, 10, 5);
+		expect(value).to.equal(23);
+	});
+
 });

--- a/lib/scripting/vbs-helper.ts
+++ b/lib/scripting/vbs-helper.ts
@@ -94,7 +94,7 @@ export class VBSHelper {
 
 	public getOrCall(obj: any, ...params: number[]) {
 		if (typeof obj === 'function') {
-			return typeof params === 'undefined' ? obj.bind(obj)() : obj.bind(obj)(...params);
+			return obj.bind(obj)(...params);
 		}
 		for (const param of params) {
 			obj = obj[param];

--- a/lib/scripting/vbs-helper.ts
+++ b/lib/scripting/vbs-helper.ts
@@ -96,9 +96,6 @@ export class VBSHelper {
 		if (typeof obj === 'function') {
 			return typeof params === 'undefined' ? obj.bind(obj)() : obj.bind(obj)(...params);
 		}
-		if (typeof params === 'undefined') {
-			return obj;
-		}
 		for (const param of params) {
 			obj = obj[param];
 		}

--- a/lib/scripting/vbs-helper.ts
+++ b/lib/scripting/vbs-helper.ts
@@ -68,7 +68,7 @@ export class VBSHelper {
 			return `//@ sourceURL=inline${this.transpileCount++}.js\n${this.transpiler.transpile(vbs)}`;
 		} else {
 			return this.transpiler.transpile(vbs);
-		}		
+		}
 	}
 
 	/**
@@ -92,14 +92,16 @@ export class VBSHelper {
 		return array;
 	}
 
-	public getOrCall(obj: any, param?: number) {
+	public getOrCall(obj: any, ...params: number[]) {
 		if (typeof obj === 'function') {
-			return typeof param === 'undefined' ? obj.bind(obj)() : obj.bind(obj)(param);
+			return typeof params === 'undefined' ? obj.bind(obj)() : obj.bind(obj)(...params);
 		}
-		if (typeof param === 'undefined') {
+		if (typeof params === 'undefined') {
 			return obj;
 		}
-		return obj[param];
+		for (const param of params) {
+			obj = obj[param];
+		}
+		return obj;
 	}
-
 }


### PR DESCRIPTION
This adds multi-dimension array and multi-parameter function support  to `vbs-helper` `getOrCall` function. 

No test case was added as I could not find a multi-dimension array in `controller.vbs`.

I was thinking we could use one like:

```
		it('should use the helper to access scope variables', () => {
			const vbs = `x = ChgGI(1, 2)\n`;
			const js = transpiler.transpile(vbs);
			expect(js).to.equal(
				`${Transformer.SCOPE_NAME}.x = ${Transformer.VBSHELPER_NAME}.getOrCall(${Transformer.SCOPE_NAME}.ChgGI, 1, 2);`,
			);
		});
```