### PR TITLE
Fix dropped animation frames

### DIFF
--- a/lib/game/ianimatable.ts
+++ b/lib/game/ianimatable.ts
@@ -36,9 +36,9 @@ export interface IAnimatable extends IPlayable {
 
 export interface IAnimation {
 
-	init(physics: PlayerPhysics): void;
+	init(timeMsec: number): void;
 
-	updateAnimation(physics: PlayerPhysics, table: Table): void;
+	updateAnimation(timeMsec: number, table: Table): void;
 }
 
 export function isAnimatable(arg: any): arg is IAnimatable {

--- a/lib/game/player-physics.ts
+++ b/lib/game/player-physics.ts
@@ -418,13 +418,13 @@ export class PlayerPhysics {
 			this.physicsSimulateCycle(physicsDiffTime); // main simulator call
 
 			// animations
-			if (Math.round(this.curPhysicsFrameTime / 1000) % ANIM_FRAME_MSEC === 0 || this.curPhysicsFrameTime - this.lastAnimTimeUsec >= ANIM_FRAME_USEC) {
-				//console.log(this.lastAnimTimeUsec)
-				for (const animatable of this.table.getAnimatables()) {
-					animatable.getAnimation().updateAnimation(this.timeMsec, this.table);
-				}
-				this.lastAnimTimeUsec = this.curPhysicsFrameTime;
-			}
+			// if (Math.round(this.curPhysicsFrameTime / 1000) % ANIM_FRAME_MSEC === 0 || this.curPhysicsFrameTime - this.lastAnimTimeUsec >= ANIM_FRAME_USEC) {
+			// 	//console.log(this.lastAnimTimeUsec)
+			// 	for (const animatable of this.table.getAnimatables()) {
+			// 		animatable.getAnimation().updateAnimation(this.timeMsec, this.table);
+			// 	}
+			// 	this.lastAnimTimeUsec = this.curPhysicsFrameTime;
+			// }
 
 			this.curPhysicsFrameTime = this.nextPhysicsFrameTime; // new cycle, on physics frame boundary
 			this.nextPhysicsFrameTime += PHYSICS_STEPTIME;     // advance physics position

--- a/lib/game/player-physics.ts
+++ b/lib/game/player-physics.ts
@@ -49,9 +49,6 @@ import { PinInput } from './pin-input';
 import { IBallCreationPosition, Player } from './player';
 
 const SLOW_MO = 1; // the lower, the slower
-const ANIM_FPS = 60;
-const ANIM_FRAME_USEC = 1 / ANIM_FPS * 1000000;
-const ANIM_FRAME_MSEC = Math.floor(1 / ANIM_FPS * 1000);
 
 export class PlayerPhysics {
 
@@ -84,7 +81,6 @@ export class PlayerPhysics {
 	private hitTimers: TimerHit[] = [];
 
 	private minPhysLoopTime: number = 0;
-	private lastAnimTimeUsec: number = 0;
 	private lastFlipTime: number = 0;
 	private lastTimeUsec: number = 0;
 	private lastFrameDuration: number = 0;
@@ -416,15 +412,6 @@ export class PlayerPhysics {
 
 			// primary physics loop
 			this.physicsSimulateCycle(physicsDiffTime); // main simulator call
-
-			// animations
-			// if (Math.round(this.curPhysicsFrameTime / 1000) % ANIM_FRAME_MSEC === 0 || this.curPhysicsFrameTime - this.lastAnimTimeUsec >= ANIM_FRAME_USEC) {
-			// 	//console.log(this.lastAnimTimeUsec)
-			// 	for (const animatable of this.table.getAnimatables()) {
-			// 		animatable.getAnimation().updateAnimation(this.timeMsec, this.table);
-			// 	}
-			// 	this.lastAnimTimeUsec = this.curPhysicsFrameTime;
-			// }
 
 			this.curPhysicsFrameTime = this.nextPhysicsFrameTime; // new cycle, on physics frame boundary
 			this.nextPhysicsFrameTime += PHYSICS_STEPTIME;     // advance physics position

--- a/lib/game/player-physics.ts
+++ b/lib/game/player-physics.ts
@@ -128,7 +128,7 @@ export class PlayerPhysics {
 
 		// [vpx-js added] init animation timers
 		for (const animatable of this.table.getAnimatables()) {
-			animatable.getAnimation().init(this);
+			animatable.getAnimation().init(this.timeMsec);
 		}
 
 		this.indexTableElements();
@@ -421,7 +421,7 @@ export class PlayerPhysics {
 			if (Math.round(this.curPhysicsFrameTime / 1000) % ANIM_FRAME_MSEC === 0 || this.curPhysicsFrameTime - this.lastAnimTimeUsec >= ANIM_FRAME_USEC) {
 				//console.log(this.lastAnimTimeUsec)
 				for (const animatable of this.table.getAnimatables()) {
-					animatable.getAnimation().updateAnimation(this, this.table);
+					animatable.getAnimation().updateAnimation(this.timeMsec, this.table);
 				}
 				this.lastAnimTimeUsec = this.curPhysicsFrameTime;
 			}

--- a/lib/game/player.ts
+++ b/lib/game/player.ts
@@ -224,20 +224,6 @@ export class Player extends EventEmitter {
 		this.width = width;
 		this.height = height;
 	}
-
-	/**
-	 * @deprecated use updatePhysics()
-	 */
-	public updateVelocities() {
-		this.physics.updateVelocities();
-	}
-
-	/**
-	 * @deprecated use updatePhysics()
-	 */
-	public physicsSimulateCycle(tickDuration: number) {
-		this.physics.physicsSimulateCycle(tickDuration);
-	}
 }
 
 export interface IBallCreationPosition {

--- a/lib/game/player.ts
+++ b/lib/game/player.ts
@@ -82,6 +82,12 @@ export class Player extends EventEmitter {
 	 * usage.
 	 */
 	public popStates(): ChangedStates<ItemState> {
+		// first, animate.
+		for (const animatable of this.table.getAnimatables()) {
+			animatable.getAnimation().updateAnimation(this.physics.timeMsec, this.table);
+		}
+
+		// now, get the states
 		const changedStates = ChangedStates.claim();
 		for (const name of Object.keys(this.currentStates)) {
 			const newState = this.currentStates[name];

--- a/lib/vpt/bumper/bumper-animation.ts
+++ b/lib/vpt/bumper/bumper-animation.ts
@@ -48,11 +48,11 @@ export class BumperAnimation implements IAnimation {
 		this.timeMsec = timeMsec;
 	}
 
-	public updateAnimation(timeMsec: number, table: Table): void {
+	public updateAnimation(newTimeMsec: number, table: Table): void {
 
-		const oldTimeMsec = this.timeMsec < timeMsec ? this.timeMsec : timeMsec;
-		this.timeMsec = timeMsec;
-		const diffTimeMsec = (timeMsec - oldTimeMsec);
+		const oldTimeMsec = this.timeMsec < newTimeMsec ? this.timeMsec : newTimeMsec;
+		this.timeMsec = newTimeMsec;
+		const diffTimeMsec = (newTimeMsec - oldTimeMsec);
 		const state = this.hitEvent ? 1 : 0;    // 0 = not hit, 1 = hit
 
 		this.updateRingAnimation(state, diffTimeMsec, table);

--- a/lib/vpt/bumper/bumper-animation.ts
+++ b/lib/vpt/bumper/bumper-animation.ts
@@ -44,15 +44,15 @@ export class BumperAnimation implements IAnimation {
 		this.state = state;
 	}
 
-	public init(physics: PlayerPhysics): void {
-		this.timeMsec = physics.timeMsec;
+	public init(timeMsec: number): void {
+		this.timeMsec = timeMsec;
 	}
 
-	public updateAnimation(physics: PlayerPhysics, table: Table): void {
+	public updateAnimation(timeMsec: number, table: Table): void {
 
-		const oldTimeMsec = this.timeMsec < physics.timeMsec ? this.timeMsec : physics.timeMsec;
-		this.timeMsec = physics.timeMsec;
-		const diffTimeMsec = (physics.timeMsec - oldTimeMsec);
+		const oldTimeMsec = this.timeMsec < timeMsec ? this.timeMsec : timeMsec;
+		this.timeMsec = timeMsec;
+		const diffTimeMsec = (timeMsec - oldTimeMsec);
 		const state = this.hitEvent ? 1 : 0;    // 0 = not hit, 1 = hit
 
 		this.updateRingAnimation(state, diffTimeMsec, table);

--- a/lib/vpt/bumper/bumper-api.spec.ts
+++ b/lib/vpt/bumper/bumper-api.spec.ts
@@ -80,10 +80,11 @@ describe('The VPinball bumper API', () => {
 
 		bumper.getApi().PlayHit();
 
-		player.updatePhysics(10);
+		player.simulateTime(10);
 		expect(bumper.getState().ringOffset).to.equal(0);
-		player.updatePhysics(20);
-		expect(bumper.getState().ringOffset).to.equal(-8);
+
+		player.simulateTime(20);
+		expect(bumper.getState().ringOffset).to.be.closeTo(-8.33, 0.01);
 	});
 
 	it('should not animate the bumper when the ring is invisible', () => {

--- a/lib/vpt/bumper/bumper-hit.spec.ts
+++ b/lib/vpt/bumper/bumper-hit.spec.ts
@@ -52,10 +52,10 @@ describe('The VPinball bumper collision', () => {
 
 		expect(ball.getState().pos.x).to.equal(450);
 
-		player.updatePhysics(500);
+		player.simulateTime(500);
 		expect(ball.getState().pos.x).to.equal(450);
 
-		player.updatePhysics(1100);
+		player.simulateTime(1100);
 		expect(ball.getState().pos.x).to.be.within(75, 85);
 		expect(ball.getState().pos.y).to.be.below(600);
 
@@ -65,10 +65,10 @@ describe('The VPinball bumper collision', () => {
 		const ball = createBall(player, 450, 750, 50, 0, 0.5);
 		expect(ball.getState().pos.x).to.equal(450);
 
-		player.updatePhysics(500);
+		player.simulateTime(500);
 		expect(ball.getState().pos.x).to.equal(450);
 
-		player.updatePhysics(1100);
+		player.simulateTime(1100);
 		expect(ball.getState().pos.x).to.be.within(430, 440);
 		expect(ball.getState().pos.y).to.be.above(800);
 	});
@@ -77,15 +77,15 @@ describe('The VPinball bumper collision', () => {
 		createBall(player, 450, 750, 50, 0, 1);
 		const bumper = table.bumpers.Bumper2;
 
-		player.updatePhysics(10);
+		player.simulateTime(10);
 		expect(bumper.getState().ringOffset).to.equal(0);
-		player.updatePhysics(700);
-		expect(bumper.getState().ringOffset).to.equal(-8);
-		player.updatePhysics(780);
-		expect(bumper.getState().ringOffset).to.equal(-45);
-		player.updatePhysics(840);
-		expect(bumper.getState().ringOffset).to.equal(-13);
-		player.updatePhysics(900);
+		player.simulateTime(700);
+		expect(bumper.getState().ringOffset).to.be.closeTo(-8.33, 0.01);
+		player.simulateTime(780);
+		expect(bumper.getState().ringOffset).to.be.closeTo(-41.66, 0.01);
+		player.simulateTime(840);
+		expect(bumper.getState().ringOffset).to.be.closeTo(-20, 0.01);
+		player.simulateTime(900);
 		expect(bumper.getState().ringOffset).to.equal(0);
 	});
 
@@ -100,19 +100,19 @@ describe('The VPinball bumper collision', () => {
 		const bumperObj = three.find<Mesh>(gltf, 'bumpers', 'Bumper2');
 		const ringObj = bumperObj.children.find(o => o.name === `bumper-ring-Bumper2`)!;
 
-		player.updatePhysics(710);
+		player.simulateTime(710);
 		let states = player.popStates();
 		let state = states.getState<BumperState>('Bumper2');
 		bumper.getUpdater().applyState(bumperObj, state, renderApi, table);
 		ringObj.getWorldPosition(ringPos);
-		expect(ringPos.z).to.equal(16);
+		expect(ringPos.z).to.be.closeTo(8.33, 0.01);
 
-		player.updatePhysics(770);
+		player.simulateTime(770);
 		states = player.popStates();
 		state = states.getState<BumperState>('Bumper2');
 		bumper.getUpdater().applyState(bumperObj, state, renderApi, table);
 		ringObj.getWorldPosition(ringPos);
-		expect(ringPos.z).to.equal(61);
+		expect(ringPos.z).to.be.closeTo(50, 0.01);
 	});
 
 });

--- a/lib/vpt/flipper/flipper-mover.spec.ts
+++ b/lib/vpt/flipper/flipper-mover.spec.ts
@@ -19,8 +19,6 @@
 
 import * as chai from 'chai';
 import { expect } from 'chai';
-import sinonChai = require('sinon-chai');
-import { simulateCycles } from '../../../test/physics.helper';
 import { ThreeHelper } from '../../../test/three.helper';
 import { Player } from '../../game/player';
 import { NodeBinaryReader } from '../../io/binary-reader.node';
@@ -28,7 +26,7 @@ import { degToRad } from '../../math/float';
 import { Table } from '../table/table';
 import { FlipperState } from './flipper-state';
 
-chai.use(sinonChai);
+chai.use(require('sinon-chai'));
 const three = new ThreeHelper();
 
 describe('The VPinball flipper physics', () => {
@@ -51,7 +49,7 @@ describe('The VPinball flipper physics', () => {
 		const endAngleRad = degToRad(flipper.getFlipperData().endAngle);
 
 		flipper.getApi().RotateToEnd();
-		simulateCycles(player, 25);
+		player.simulateTime(100);
 
 		expect(flipperState.angle).to.equal(endAngleRad);
 	});
@@ -64,11 +62,11 @@ describe('The VPinball flipper physics', () => {
 
 		// move up
 		flipper.getApi().RotateToEnd();
-		simulateCycles(player, 25); // hit at 17.012061224193429107ms (at 1000fps)
+		player.updatePhysics(52); // hit at 51ms
 
 		// move down again
 		flipper.getApi().RotateToStart();
-		simulateCycles(player, 80);
+		player.updatePhysics(300);
 
 		expect(flipperState.angle).to.equal(startAngleRad);
 	});
@@ -82,20 +80,20 @@ describe('The VPinball flipper physics', () => {
 
 		// move up
 		flipper.getApi().RotateToEnd();
-		simulateCycles(player, 25); // hit at 17.012061224193429107ms (at 1000fps)
+		player.updatePhysics(52); // hit at 51ms
+		expect(flipperState.angle).to.be.above(startAngleRad);
 
 		// move down
 		flipper.getApi().RotateToStart();
-		simulateCycles(player, 25);
+		player.updatePhysics(200);
 
 		// assert it's in the middle
-		const turningAngle = flipperState.angle;
-		expect(turningAngle).to.be.above(startAngleRad);
-		expect(turningAngle).to.be.below(endAngleRad);
+		expect(flipperState.angle).to.be.above(startAngleRad);
+		expect(flipperState.angle).to.be.below(endAngleRad);
 
 		// move up again
 		flipper.getApi().RotateToEnd();
-		simulateCycles(player, 10);
+		player.updatePhysics(500);
 
 		// assert it's back up in less than half the time
 		expect(flipperState.angle).to.equal(endAngleRad);
@@ -106,7 +104,7 @@ describe('The VPinball flipper physics', () => {
 
 		// move up
 		flipper.getApi().RotateToEnd();
-		simulateCycles(player, 25); // hit at 17.012061224193429107ms (at 1000fps)
+		player.simulateTime(25); // hit at 17.012061224193429107ms (at 1000fps)
 
 		const flipperState = flipper.getState();
 		const states = player.popStates();

--- a/lib/vpt/hit-target/hit-target-animation.ts
+++ b/lib/vpt/hit-target/hit-target-animation.ts
@@ -44,14 +44,14 @@ export class HitTargetAnimation implements IAnimation {
 		this.events = events;
 	}
 
-	public init(physics: PlayerPhysics): void {
-		this.timeMsec = physics.timeMsec;
+	public init(timeMsec: number): void {
+		this.timeMsec = timeMsec;
 	}
 
-	public updateAnimation(physics: PlayerPhysics, table: Table): void {
-		const oldTimeMsec = (this.timeMsec < physics.timeMsec) ? this.timeMsec : physics.timeMsec;
-		this.timeMsec = physics.timeMsec;
-		const diffTimeMsec = physics.timeMsec - oldTimeMsec;
+	public updateAnimation(timeMsec: number, table: Table): void {
+		const oldTimeMsec = (this.timeMsec < timeMsec) ? this.timeMsec : timeMsec;
+		this.timeMsec = timeMsec;
+		const diffTimeMsec = timeMsec - oldTimeMsec;
 
 		if (this.hitEvent) {
 			if (!this.data.isDropped) {

--- a/lib/vpt/hit-target/hit-target-animation.ts
+++ b/lib/vpt/hit-target/hit-target-animation.ts
@@ -48,10 +48,10 @@ export class HitTargetAnimation implements IAnimation {
 		this.timeMsec = timeMsec;
 	}
 
-	public updateAnimation(timeMsec: number, table: Table): void {
-		const oldTimeMsec = (this.timeMsec < timeMsec) ? this.timeMsec : timeMsec;
-		this.timeMsec = timeMsec;
-		const diffTimeMsec = timeMsec - oldTimeMsec;
+	public updateAnimation(newTimeMsec: number, table: Table): void {
+		const oldTimeMsec = (this.timeMsec < newTimeMsec) ? this.timeMsec : newTimeMsec;
+		this.timeMsec = newTimeMsec;
+		const diffTimeMsec = newTimeMsec - oldTimeMsec;
 
 		if (this.hitEvent) {
 			if (!this.data.isDropped) {

--- a/lib/vpt/hit-target/hit-target-api.spec.ts
+++ b/lib/vpt/hit-target/hit-target-api.spec.ts
@@ -97,7 +97,7 @@ describe('The VPinball hit target API', () => {
 		expect(dropTarget.IsDropped).to.equal(false); // still raised
 
 		// animate down
-		player.updatePhysics(200);
+		player.simulateTime(200);
 		expect(dropTarget.IsDropped).to.equal(true);
 
 		// set to raised
@@ -105,7 +105,7 @@ describe('The VPinball hit target API', () => {
 		expect(dropTarget.IsDropped).to.equal(true); // still dropped
 
 		// animate up
-		player.updatePhysics(420);
+		player.simulateTime(420);
 		expect(dropTarget.IsDropped).to.equal(false);
 
 	});

--- a/lib/vpt/hit-target/hit-target-hit.spec.ts
+++ b/lib/vpt/hit-target/hit-target-hit.spec.ts
@@ -68,7 +68,7 @@ describe('The VPinball hit target collision', () => {
 			const ball = createBall(player, dropTarget.X, dropTarget.Y + 100, 0, 0, -10);
 
 			// assert ball moving up
-			player.updatePhysics(200);
+			player.simulateTime(200);
 			expect(ball.getState().pos.y).to.be.above(1130);
 
 			player.destroyBall(ball);
@@ -76,11 +76,11 @@ describe('The VPinball hit target collision', () => {
 			const ball2 = createBall(player, dropTarget.X, dropTarget.Y + 100, 0, 0, -10);
 			//debugBall(player, ball2, 300, 5, 200);
 
-			player.updatePhysics(300);
+			player.simulateTime(300);
 			expect(ball2.getState().pos.y).to.be.below(1085);
-			player.updatePhysics(500);
-			expect(ball2.getState().pos.y).to.be.below(940);
-			player.updatePhysics(1000);
+			player.simulateTime(500);
+			expect(ball2.getState().pos.y).to.be.below(947);
+			player.simulateTime(1000);
 			expect(ball2.getState().pos.y).to.be.below(610);
 		});
 
@@ -91,11 +91,11 @@ describe('The VPinball hit target collision', () => {
 			// drop
 			dropTarget.IsDropped = true;
 
-			player.updatePhysics(100);
-			expect(ball.getState().pos.y).to.be.below(1290);
-			player.updatePhysics(550);
+			player.simulateTime(100);
+			expect(ball.getState().pos.y).to.be.below(1299);
+			player.simulateTime(550);
 			expect(ball.getState().pos.y).to.be.below(1000);
-			player.updatePhysics(1000);
+			player.simulateTime(1000);
 			expect(ball.getState().pos.y).to.be.below(690);
 		});
 	});
@@ -140,7 +140,7 @@ describe('The VPinball hit target collision', () => {
 		const dropTarget = table.hitTargets.DropTargetBeveled.getApi();
 		dropTarget.IsDropped = true;
 
-		player.updatePhysics(200);
+		player.simulateTime(200);
 		const state = player.popStates().getState<HitTargetState>('DropTargetBeveled');
 		expect(state.zOffset).to.equal(table.hitTargets.DropTargetBeveled.getState().zOffset);
 	});

--- a/lib/vpt/light/light-animation.spec.ts
+++ b/lib/vpt/light/light-animation.spec.ts
@@ -104,11 +104,6 @@ describe('The VPinball light animation', () => {
 
 		api.Duration(Enums.LightStatus.LightStateOff, 500, Enums.LightStatus.LightStateBlinking);
 
-		// for (let i = 0; i < 3000; i += 10) {
-		// 	player.simulateTime(i);
-		// 	console.log('%s %s', i, light.getState().intensity);
-		// }
-
 		player.simulateTime(520);
 		expect(light.getState().intensity).to.equal(1);
 

--- a/lib/vpt/light/light-animation.spec.ts
+++ b/lib/vpt/light/light-animation.spec.ts
@@ -48,11 +48,11 @@ describe('The VPinball light animation', () => {
 		api.State = Enums.LightStatus.LightStateOff;
 		api.Intensity = 1;
 
-		player.updatePhysics(0);
+		player.simulateTime(0);
 		expect(light.getState().intensity).to.equal(0);
 
 		api.State = Enums.LightStatus.LightStateOn;
-		player.updatePhysics(20);
+		player.simulateTime(20);
 		expect(light.getState().intensity).to.equal(1);
 	});
 
@@ -63,11 +63,11 @@ describe('The VPinball light animation', () => {
 		api.State = Enums.LightStatus.LightStateOn;
 		api.Intensity = 1;
 
-		player.updatePhysics(0);
+		player.simulateTime(0);
 		expect(light.getState().intensity).to.equal(1);
 
 		api.State = Enums.LightStatus.LightStateOff;
-		player.updatePhysics(20);
+		player.simulateTime(20);
 		expect(light.getState().intensity).to.equal(0);
 	});
 
@@ -79,15 +79,15 @@ describe('The VPinball light animation', () => {
 		api.State = Enums.LightStatus.LightStateOff;
 		api.Intensity = 1;
 
-		player.updatePhysics(0);
+		player.simulateTime(0);
 		expect(light.getState().intensity).to.equal(0);
 
 		api.Duration(Enums.LightStatus.LightStateOff, 500, Enums.LightStatus.LightStateOn);
 
-		player.updatePhysics(520);
+		player.simulateTime(520);
 		expect(light.getState().intensity).to.equal(1);
 
-		player.updatePhysics(650);
+		player.simulateTime(650);
 		expect(light.getState().intensity).to.equal(1);
 	});
 
@@ -99,23 +99,23 @@ describe('The VPinball light animation', () => {
 		api.State = Enums.LightStatus.LightStateOff;
 		api.Intensity = 1;
 
-		player.updatePhysics(0);
+		player.simulateTime(0);
 		expect(light.getState().intensity).to.equal(0);
 
 		api.Duration(Enums.LightStatus.LightStateOff, 500, Enums.LightStatus.LightStateBlinking);
 
 		// for (let i = 0; i < 3000; i += 10) {
-		// 	player.updatePhysics(i);
+		// 	player.simulateTime(i);
 		// 	console.log('%s %s', i, light.getState().intensity);
 		// }
 
-		player.updatePhysics(520);
+		player.simulateTime(520);
 		expect(light.getState().intensity).to.equal(1);
 
-		player.updatePhysics(650);
+		player.simulateTime(650);
 		expect(light.getState().intensity).to.equal(0);
 
-		player.updatePhysics(770);
+		player.simulateTime(770);
 		expect(light.getState().intensity).to.equal(1);
 	});
 
@@ -127,18 +127,18 @@ describe('The VPinball light animation', () => {
 		api.State = Enums.LightStatus.LightStateOff;
 		api.Intensity = 1;
 
-		player.updatePhysics(0);
+		player.simulateTime(0);
 		expect(light.getState().intensity).to.equal(0);
 
 		api.Duration(Enums.LightStatus.LightStateBlinking, 500, Enums.LightStatus.LightStateOff);
 
-		player.updatePhysics(20);
+		player.simulateTime(20);
 		expect(light.getState().intensity).to.equal(1);
 
-		player.updatePhysics(120);
+		player.simulateTime(120);
 		expect(light.getState().intensity).to.equal(1);
 
-		player.updatePhysics(130);
+		player.simulateTime(140);
 		expect(light.getState().intensity).to.equal(0);
 	});
 
@@ -152,22 +152,22 @@ describe('The VPinball light animation', () => {
 		api.Intensity = 10;
 		api.IntensityScale = 1;
 
-		player.updatePhysics(100);
+		player.simulateTime(50);
 		expect(light.getState().intensity).to.equal(10);
 
-		player.updatePhysics(200);
+		player.simulateTime(150);
 		expect(light.getState().intensity).to.equal(0);
 
-		player.updatePhysics(300);
+		player.simulateTime(250);
 		expect(light.getState().intensity).to.equal(0);
 
-		player.updatePhysics(400);
+		player.simulateTime(350);
 		expect(light.getState().intensity).to.equal(10);
 
-		player.updatePhysics(500);
+		player.simulateTime(450);
 		expect(light.getState().intensity).to.equal(10);
 
-		player.updatePhysics(600);
+		player.simulateTime(550);
 		expect(light.getState().intensity).to.equal(0);
 	});
 
@@ -181,28 +181,28 @@ describe('The VPinball light animation', () => {
 		api.Intensity = 10;
 		api.IntensityScale = 1;
 
-		player.updatePhysics(100);
+		player.simulateTime(100);
 		expect(light.getState().intensity).to.equal(10);
 
-		player.updatePhysics(200);
+		player.simulateTime(200);
 		expect(light.getState().intensity).to.equal(0);
 
-		player.updatePhysics(300);
+		player.simulateTime(300);
 		expect(light.getState().intensity).to.equal(10);
 
-		player.updatePhysics(400);
+		player.simulateTime(400);
 		expect(light.getState().intensity).to.equal(10);
 
-		player.updatePhysics(500);
+		player.simulateTime(500);
 		expect(light.getState().intensity).to.equal(0);
 
-		player.updatePhysics(600);
+		player.simulateTime(600);
 		expect(light.getState().intensity).to.equal(10);
 
-		player.updatePhysics(700);
+		player.simulateTime(700);
 		expect(light.getState().intensity).to.equal(10);
 
-		player.updatePhysics(800);
+		player.simulateTime(800);
 		expect(light.getState().intensity).to.equal(0);
 	});
 
@@ -218,31 +218,31 @@ describe('The VPinball light animation', () => {
 		api.FadeSpeedDown = 0.3;
 		api.FadeSpeedUp = 0.4;
 
-		player.updatePhysics(600);
+		player.simulateTime(590);
 		expect(light.getState().intensity).to.equal(100);
 
-		player.updatePhysics(640);
+		player.simulateTime(630);
 		expect(light.getState().intensity).to.be.within(90, 91);
 
-		player.updatePhysics(770);
-		expect(light.getState().intensity).to.be.within(47, 48);
+		player.simulateTime(770);
+		expect(light.getState().intensity).to.be.within(44, 46);
 
-		player.updatePhysics(910);
-		expect(light.getState().intensity).to.be.within(7, 9);
+		player.simulateTime(910);
+		expect(light.getState().intensity).to.be.within(5, 6);
 
-		player.updatePhysics(940);
+		player.simulateTime(940);
 		expect(light.getState().intensity).to.equal(0);
 
-		player.updatePhysics(1230);
-		expect(light.getState().intensity).to.be.within(12, 13);
+		player.simulateTime(1230);
+		expect(light.getState().intensity).to.be.within(6, 7);
 
-		player.updatePhysics(1330);
-		expect(light.getState().intensity).to.be.within(57, 58);
+		player.simulateTime(1330);
+		expect(light.getState().intensity).to.be.within(46, 47);
 
-		player.updatePhysics(1420);
-		expect(light.getState().intensity).to.be.within(89, 91);
+		player.simulateTime(1420);
+		expect(light.getState().intensity).to.be.within(86, 87);
 
-		player.updatePhysics(1450);
+		player.simulateTime(1460);
 		expect(light.getState().intensity).to.equal(100);
 	});
 
@@ -251,7 +251,7 @@ describe('The VPinball light animation', () => {
 		const api = light.getApi();
 
 		api.State = Enums.LightStatus.LightStateBlinking;
-		player.updatePhysics(200);
+		player.simulateTime(200);
 
 		const state = player.popStates().getState<LightState>('Surface');
 		expect(state.intensity).to.equal(table.lights.Surface.getState().intensity);

--- a/lib/vpt/light/light-animation.ts
+++ b/lib/vpt/light/light-animation.ts
@@ -70,25 +70,25 @@ export class LightAnimation implements IAnimation {
 		this.timerDurationEndTime = timeMsec + this.duration;
 	}
 
-	public updateAnimation(physics: PlayerPhysics, table: Table): void {
+	public updateAnimation(timeMsec: number, table: Table): void {
 
 		if (!this.data.isVisible) {
 			return;
 		}
 
-		const oldTimeMsec = this.timeMsec < physics.timeMsec ? this.timeMsec : physics.timeMsec;
-		this.timeMsec = physics.timeMsec;
-		const diffTimeMsec = physics.timeMsec - oldTimeMsec;
+		const oldTimeMsec = this.timeMsec < timeMsec ? this.timeMsec : timeMsec;
+		this.timeMsec = timeMsec;
+		const diffTimeMsec = timeMsec - oldTimeMsec;
 
 		if (this.duration > 0 && this.timerDurationEndTime < this.timeMsec) {
 			this.realState = this.finalState;
 			this.duration = 0;
 			if (this.realState === Enums.LightStatus.LightStateBlinking) {
-				this.restartBlinker(physics.timeMsec);
+				this.restartBlinker(timeMsec);
 			}
 		}
 		if (this.realState === Enums.LightStatus.LightStateBlinking) {
-			this.updateBlinker(physics.timeMsec);
+			this.updateBlinker(timeMsec);
 		}
 
 		if (this.isOn()) {

--- a/lib/vpt/light/light-animation.ts
+++ b/lib/vpt/light/light-animation.ts
@@ -70,25 +70,25 @@ export class LightAnimation implements IAnimation {
 		this.timerDurationEndTime = timeMsec + this.duration;
 	}
 
-	public updateAnimation(timeMsec: number, table: Table): void {
+	public updateAnimation(newTimeMsec: number, table: Table): void {
 
 		if (!this.data.isVisible) {
 			return;
 		}
 
-		const oldTimeMsec = this.timeMsec < timeMsec ? this.timeMsec : timeMsec;
-		this.timeMsec = timeMsec;
-		const diffTimeMsec = timeMsec - oldTimeMsec;
+		const oldTimeMsec = this.timeMsec < newTimeMsec ? this.timeMsec : newTimeMsec;
+		this.timeMsec = newTimeMsec;
+		const diffTimeMsec = newTimeMsec - oldTimeMsec;
 
 		if (this.duration > 0 && this.timerDurationEndTime < this.timeMsec) {
 			this.realState = this.finalState;
 			this.duration = 0;
 			if (this.realState === Enums.LightStatus.LightStateBlinking) {
-				this.restartBlinker(timeMsec);
+				this.restartBlinker(newTimeMsec);
 			}
 		}
 		if (this.realState === Enums.LightStatus.LightStateBlinking) {
-			this.updateBlinker(timeMsec);
+			this.updateBlinker(newTimeMsec);
 		}
 
 		if (this.isOn()) {

--- a/lib/vpt/plunger/plunger-mover.spec.ts
+++ b/lib/vpt/plunger/plunger-mover.spec.ts
@@ -65,13 +65,7 @@ describe('The VPinball plunger physics', () => {
 		const endPosition = plunger.getApi().Y;
 
 		plunger.pullBack();
-
-		for (let i = 0; i < 1000; i += 5) {
-			player.simulateTime(i);
-			console.log('%s: %s', i, plunger.getState().frame);
-		}
-
-		player.simulateTime(50);
+		player.simulateTime(1000);
 
 		const plungerState = popState(player, 'CustomPlunger');
 		expect(plungerState.frame).to.equal(0);

--- a/lib/vpt/trigger/trigger-animation.ts
+++ b/lib/vpt/trigger/trigger-animation.ts
@@ -53,10 +53,10 @@ export class TriggerAnimation implements IAnimation {
 		this.unhitEvent = true;
 	}
 
-	public updateAnimation(timeMsec: number, table: Table) {
-		const oldTimeMsec = (this.timeMsec < timeMsec) ? this.timeMsec : timeMsec;
-		this.timeMsec = timeMsec;
-		const diffTimeMsec = timeMsec - oldTimeMsec;
+	public updateAnimation(newTimeMsec: number, table: Table) {
+		const oldTimeMsec = (this.timeMsec < newTimeMsec) ? this.timeMsec : newTimeMsec;
+		this.timeMsec = newTimeMsec;
+		const diffTimeMsec = newTimeMsec - oldTimeMsec;
 
 		let animLimit = this.data.shape === Enums.TriggerShape.TriggerStar ? this.data.radius * (1.0 / 5.0) : 32.0;
 		if (this.data.shape === Enums.TriggerShape.TriggerButton) {

--- a/lib/vpt/trigger/trigger-animation.ts
+++ b/lib/vpt/trigger/trigger-animation.ts
@@ -53,10 +53,10 @@ export class TriggerAnimation implements IAnimation {
 		this.unhitEvent = true;
 	}
 
-	public updateAnimation(physics: PlayerPhysics, table: Table) {
-		const oldTimeMsec = (this.timeMsec < physics.timeMsec) ? this.timeMsec : physics.timeMsec;
-		this.timeMsec = physics.timeMsec;
-		const diffTimeMsec = physics.timeMsec - oldTimeMsec;
+	public updateAnimation(timeMsec: number, table: Table) {
+		const oldTimeMsec = (this.timeMsec < timeMsec) ? this.timeMsec : timeMsec;
+		this.timeMsec = timeMsec;
+		const diffTimeMsec = timeMsec - oldTimeMsec;
 
 		let animLimit = this.data.shape === Enums.TriggerShape.TriggerStar ? this.data.radius * (1.0 / 5.0) : 32.0;
 		if (this.data.shape === Enums.TriggerShape.TriggerButton) {

--- a/lib/vpt/trigger/trigger-hit.spec.ts
+++ b/lib/vpt/trigger/trigger-hit.spec.ts
@@ -50,18 +50,18 @@ describe('The VPinball trigger collision', () => {
 		kicker.Kick(0, -1);
 
 		// let it roll down some
-		player.updatePhysics(0);
-		player.updatePhysics(750);
+		player.simulateTime(0);
+		player.simulateTime(750);
 
 		expect(trigger.getState().heightOffset).to.equal(0);
 
 		// let it collide
-		player.updatePhysics(800);
+		player.simulateTime(800);
 
 		expect(trigger.getState().heightOffset).to.equal(-32);
 
 		// let it roll over and animate back
-		player.updatePhysics(1150);
+		player.simulateTime(1150);
 
 		expect(trigger.getState().heightOffset).to.equal(0);
 	});
@@ -71,18 +71,18 @@ describe('The VPinball trigger collision', () => {
 		createBall(player, 174, 1300, 0, 0, 2);
 
 		// let it roll down some
-		player.updatePhysics(0);
-		player.updatePhysics(500);
+		player.simulateTime(0);
+		player.simulateTime(500);
 
 		expect(trigger.getState().heightOffset).to.equal(0);
 
 		// let it collide
-		player.updatePhysics(600);
+		player.simulateTime(600);
 
 		expect(trigger.getState().heightOffset).to.equal(-2.5);
 
 		// let it roll over and animate back
-		player.updatePhysics(820);
+		player.simulateTime(820);
 
 		expect(trigger.getState().heightOffset).to.equal(0);
 	});
@@ -99,8 +99,8 @@ describe('The VPinball trigger collision', () => {
 		// }
 
 		// let it roll onto trigger
-		player.updatePhysics(0);
-		player.updatePhysics(900);
+		player.simulateTime(0);
+		player.simulateTime(900);
 		const state = player.popStates().getState<TriggerState>('WireB');
 		expect(state.heightOffset).to.equal(trigger.getState().heightOffset);
 	});

--- a/test/physics.helper.ts
+++ b/test/physics.helper.ts
@@ -24,22 +24,6 @@ import { Player } from '../lib/game/player';
 import { Table } from '../lib/vpt/table/table';
 
 /**
- * Simulates a given number of milliseconds.
- *
- * @param player Player object
- * @param duration Duration in milliseconds
- * @param tickDuration How many ticks to simulate (default 1ms per tick)
- */
-export function simulateCycles(player: Player, duration: number, tickDuration = 1) {
-	const numTicks = Math.floor(duration / tickDuration);
-	for (let i = 0; i < numTicks; i++) {
-		player.updateVelocities();
-		player.physicsSimulateCycle(tickDuration);
-	}
-
-}
-
-/**
  * Creates a ball at the given position
  * @param player
  * @param x Position at x


### PR DESCRIPTION
This PR moves the animation updates from the physics loop into a separate method. 

Contrarily to the physics loop, animations are only calculated once per frame. We previously solved that by doing it in the physics loop:

```ts
if (Math.round(this.curPhysicsFrameTime / 1000) % ANIM_FRAME_MSEC === 0 || this.curPhysicsFrameTime - this.lastAnimTimeUsec >= ANIM_FRAME_USEC) {
	// update animations
}
```

Which reads:

> If current time is a multiple of 16.666 (frame duration at 60fps), update.

The problem with this approach is that the physics loop is not in sync with the main loop, resulting in frames being dropped from time to time. Example:

1. `0ms` - Physics loop executes and updates animations
2. `15ms` - State update request from main thread comes in. Animations from 0ms are returned.
3. `17ms` - Physics loop and animations update
5. `33ms` - Physics loop and animations update
4. `34ms` - State update request was a few ms delayed. Animations from 33ms are returned (⚠️update skipped)
5. `49ms` - State update request caught up. Still same state from 33ms returned (⚠️frame skipped)
6. `50ms` - Physics loop and animations update

The reason the state updates can be delayed and "catch up" is that they are passed through messages, and the time for passing those messages are vary. In the above example, we saw that the main thread missed updates from two animation states.

To solve this, the `Player` now has an additional `updateAnimations()` method, which updates animations separately. It also has an `onFrame()` method, which executes `updateAnimations()` and returns the changed states. For the client app, this replaces `popStates()`.

Now, the client's clock defines when animations are updated. If a message is delayed, the animations are updated at the delayed time. Frame drops don't occur anymore.

However, for the tests that's a problem, because we just want to do `player.updatePhysics(timeToTest)` and expect multiple frames to be updated if the simulated time is greater than a frame duration. That's why we now also have a `player.simulateTime(timeToTest)` method, which drives both the physics loop and updates the animations.

Lastly, this PR removes the deprecated `simulateCycles()` test method and replaces it with the proper `player.updatePhysics()` and `player.simulateTime()` methods.