### PR TITLE
Feature/wpc implementation

### DIFF
--- a/lib/game/iemulator.ts
+++ b/lib/game/iemulator.ts
@@ -37,7 +37,7 @@ export interface IEmulator {
 	/**
 	 * Returns the frame buffer of the DMD.
 	 *
-	 * Top-right to bottom-left array, one byte per pixel, with values from 0 to 3
+	 * top-left to bottom-right array, one byte per pixel, with values from 0 to 3
 	 *
 	 * TODO will probably change to use bit planes and cut size by four.
 	 */

--- a/lib/game/iemulator.ts
+++ b/lib/game/iemulator.ts
@@ -17,6 +17,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { Vertex2D } from '../math/vertex2d';
+
 export interface IEmulator {
 
 	/**
@@ -31,4 +33,20 @@ export interface IEmulator {
 	 * @param dTime Time passed since last cycle in milliseconds (as double)
 	 */
 	emuSimulateCycle(dTime: number): void;
+
+	/**
+	 * Returns the frame buffer of the DMD.
+	 *
+	 * Top-right to bottom-left array, one byte per pixel, with values from 0 to 3
+	 *
+	 * TODO will probably change to use bit planes and cut size by four.
+	 */
+	getDmdFrame(): Uint8Array;
+
+	/**
+	 * Returns the current DMD dimensions.
+	 *
+	 * @return Vector where `x` is the width and `y` the height.
+	 */
+	getDmdDimensions(): Vertex2D;
 }

--- a/lib/game/iemulator.ts
+++ b/lib/game/iemulator.ts
@@ -60,5 +60,5 @@ export interface IEmulator {
 	 * @param switchNr which switch number (11..88) to modifiy
 	 * @param optionalEnableSwitch if this parameter is missing, the switch will be toggled, else set to the defined state
 	 */
-	setSwitchInput(switchNr: number, optionalEnableSwitch?: number): void;
+	setSwitchInput(switchNr: number, optionalEnableSwitch?: boolean): void;
 }

--- a/lib/game/iemulator.ts
+++ b/lib/game/iemulator.ts
@@ -49,4 +49,16 @@ export interface IEmulator {
 	 * @return Vector where `x` is the width and `y` the height.
 	 */
 	getDmdDimensions(): Vertex2D;
+
+	/**
+	 * trigger a cabinet key (like ESC, -, +, ENTER)
+	 */
+	setCabinetInput(keyNr: number): void;
+
+	/**
+	 * Update Switch State
+	 * @param switchNr which switch number (11..88) to modifiy
+	 * @param optionalEnableSwitch if this parameter is missing, the switch will be toggled, else set to the defined state
+	 */
+	setSwitchInput(switchNr: number, optionalEnableSwitch?: number): void;
 }

--- a/lib/game/player-physics.ts
+++ b/lib/game/player-physics.ts
@@ -406,7 +406,8 @@ export class PlayerPhysics {
 
 			// emulator loop
 			if (this.emu) {
-				this.emu.emuSimulateCycle(physicsDiffTime);
+				const deltaTimeMs = physicsDiffTime * 10;
+				this.emu.emuSimulateCycle(deltaTimeMs);
 			}
 
 			this.updateVelocities();

--- a/lib/game/player-physics.ts
+++ b/lib/game/player-physics.ts
@@ -104,6 +104,7 @@ export class PlayerPhysics {
 	/**
 	 * Player physics are instantiated in the Player's constructor.
 	 * @param table
+	 * @param pinInput
 	 */
 	constructor(table: Table, pinInput: PinInput) {
 		this.table = table;

--- a/lib/game/player.ts
+++ b/lib/game/player.ts
@@ -28,6 +28,7 @@ import { IEmulator } from './iemulator';
 import { AssignKey, keyEventToDirectInputKey } from './key-code';
 import { PinInput } from './pin-input';
 import { PlayerPhysics } from './player-physics';
+import { Vertex2D } from '../math/vertex2d';
 
 export class Player extends EventEmitter {
 
@@ -208,6 +209,18 @@ export class Player extends EventEmitter {
 
 	public setEmulator(emu: IEmulator) {
 		this.physics.emu = emu;
+	}
+
+	public hasDmd(): boolean {
+		return !!this.physics.emu && !!this.physics.emu.getDmdDimensions();
+	}
+
+	public getDmdDimensions(): Vertex2D {
+		return this.physics.emu!.getDmdDimensions();
+	}
+
+	public getDmdFrame(): Uint8Array {
+		return this.physics.emu!.getDmdFrame();
 	}
 
 	/**

--- a/lib/game/player.ts
+++ b/lib/game/player.ts
@@ -229,7 +229,7 @@ export class Player extends EventEmitter {
 		}
 	}
 
-	public setSwitchInput(switchNr: number, optionalEnableSwitch?: number) {
+	public setSwitchInput(switchNr: number, optionalEnableSwitch?: boolean) {
 		if (this.physics.emu) {
 			this.physics.emu.setSwitchInput(switchNr, optionalEnableSwitch)
 		}

--- a/lib/game/player.ts
+++ b/lib/game/player.ts
@@ -28,7 +28,6 @@ import { IEmulator } from './iemulator';
 import { AssignKey, keyEventToDirectInputKey } from './key-code';
 import { PinInput } from './pin-input';
 import { PlayerPhysics } from './player-physics';
-import { Vertex2D } from '../math/vertex2d';
 
 export class Player extends EventEmitter {
 

--- a/lib/game/player.ts
+++ b/lib/game/player.ts
@@ -223,6 +223,18 @@ export class Player extends EventEmitter {
 		return this.physics.emu!.getDmdFrame();
 	}
 
+	public setCabinetInput(keyNr: number) {
+		if (this.physics.emu) {
+			this.physics.emu.setCabinetInput(keyNr);
+		}
+	}
+
+	public setSwitchInput(switchNr: number, optionalEnableSwitch?: number) {
+		if (this.physics.emu) {
+			this.physics.emu.setSwitchInput(switchNr, optionalEnableSwitch)
+		}
+	}
+
 	/**
 	 * Sets the dimensions of the render frame.
 	 *

--- a/lib/render/threejs/three-light-generator.ts
+++ b/lib/render/threejs/three-light-generator.ts
@@ -17,7 +17,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { AdditiveBlending, Mesh as ThreeMesh, MeshStandardMaterial, Object3D, PointLight, Vector2 } from '../../refs.node';
+import { Mesh as ThreeMesh, MeshStandardMaterial, Object3D, PointLight, Vector2 } from '../../refs.node';
 import { Enums } from '../../vpt/enums';
 import { LightData } from '../../vpt/light/light-data';
 import { LightState } from '../../vpt/light/light-state';
@@ -25,8 +25,10 @@ import { ThreeRenderApi } from './three-render-api';
 
 export class ThreeLightGenerator {
 
-	public static readonly EMISSIVE_MAP_FACTOR = 4;
+	public static readonly EMISSIVE_MAP_FACTOR = 0.1;
 	public static readonly BULB_FACTOR = 0.3;
+
+	private readonly hsl: any = {};
 
 	public createPointLight(lightData: LightData): PointLight {
 		const light = new PointLight(lightData.color, lightData.state !== Enums.LightStatus.LightStateOff ? lightData.intensity * ThreeLightGenerator.BULB_FACTOR : 0, lightData.falloff * ThreeRenderApi.SCALE, 2);
@@ -52,35 +54,23 @@ export class ThreeLightGenerator {
 		}
 		for (const lightObj of obj.children) {
 			if (lightObj.name === 'light') {
-				if (state.intensity) {
-					(lightObj as PointLight).intensity = state.intensity * ThreeLightGenerator.BULB_FACTOR;
-				}
-				if (state.color) {
-					(lightObj as PointLight).color.set(state.color);
-				}
+				const pointLight = lightObj as PointLight;
+				pointLight.intensity = state.intensity * ThreeLightGenerator.BULB_FACTOR;
+				pointLight.color.set(state.color);
 			}
 			if (lightObj.name === 'bulb.light') {
-				if (state.intensity) {
-					((lightObj as ThreeMesh).material as MeshStandardMaterial).emissiveIntensity = state.intensity / initialIntensity;
-				}
-				if (state.color) {
-					((lightObj as ThreeMesh).material as MeshStandardMaterial).color.set(state.color);
-					((lightObj as ThreeMesh).material as MeshStandardMaterial).emissive.set(state.color);
-				}
+				const bulb = lightObj as ThreeMesh;
+				const bulbMat = bulb.material as MeshStandardMaterial;
+				bulbMat.emissiveIntensity = state.intensity / initialIntensity;
+				bulbMat.color.set(state.color);
+				bulbMat.emissive.set(state.color);
 			}
 			if (lightObj.name === 'surface.light') {
 				const mat = ((lightObj as ThreeMesh).material as MeshStandardMaterial);
-				if (state.intensity) {
-					const intensity = state.intensity / initialIntensity;
-					mat.emissiveIntensity = intensity * ThreeLightGenerator.EMISSIVE_MAP_FACTOR;
-					mat.blending = AdditiveBlending;
-					const hsl: any = {};
-					mat.emissive.getHSL(hsl);
-					mat.emissive.setHSL(hsl.h, hsl.s, intensity);
-				}
-				if (state.color) {
-					mat.emissive.set(state.color);
-				}
+				mat.emissiveIntensity = state.intensity * ThreeLightGenerator.EMISSIVE_MAP_FACTOR;
+				mat.emissive.set(state.color);
+				mat.emissive.getHSL(this.hsl);
+				mat.emissive.setHSL(this.hsl.h, this.hsl.s, this.hsl.l * 1.25);
 			}
 		}
 	}

--- a/lib/render/threejs/three-light-generator.ts
+++ b/lib/render/threejs/three-light-generator.ts
@@ -26,9 +26,10 @@ import { ThreeRenderApi } from './three-render-api';
 export class ThreeLightGenerator {
 
 	private static readonly EMISSIVE_MAP_FACTOR = 4;
+	private static readonly BULB_FACTOR = 0.3;
 
 	public createPointLight(lightData: LightData): PointLight {
-		const light = new PointLight(lightData.color, lightData.state !== Enums.LightStatus.LightStateOff ? lightData.intensity : 0, lightData.falloff * ThreeRenderApi.SCALE, 2);
+		const light = new PointLight(lightData.color, lightData.state !== Enums.LightStatus.LightStateOff ? lightData.intensity * ThreeLightGenerator.BULB_FACTOR : 0, lightData.falloff * ThreeRenderApi.SCALE, 2);
 		light.name = `light`;
 		light.color.set(lightData.color);
 		light.updateMatrixWorld();
@@ -52,7 +53,7 @@ export class ThreeLightGenerator {
 		for (const lightObj of obj.children) {
 			if (lightObj.name === 'light') {
 				if (state.intensity) {
-					(lightObj as PointLight).intensity = state.intensity;
+					(lightObj as PointLight).intensity = state.intensity * ThreeLightGenerator.BULB_FACTOR;
 				}
 				if (state.color) {
 					(lightObj as PointLight).color.set(state.color);

--- a/lib/render/threejs/three-light-generator.ts
+++ b/lib/render/threejs/three-light-generator.ts
@@ -25,8 +25,8 @@ import { ThreeRenderApi } from './three-render-api';
 
 export class ThreeLightGenerator {
 
-	private static readonly EMISSIVE_MAP_FACTOR = 4;
-	private static readonly BULB_FACTOR = 0.3;
+	public static readonly EMISSIVE_MAP_FACTOR = 4;
+	public static readonly BULB_FACTOR = 0.3;
 
 	public createPointLight(lightData: LightData): PointLight {
 		const light = new PointLight(lightData.color, lightData.state !== Enums.LightStatus.LightStateOff ? lightData.intensity * ThreeLightGenerator.BULB_FACTOR : 0, lightData.falloff * ThreeRenderApi.SCALE, 2);

--- a/lib/render/threejs/three-material-generator.ts
+++ b/lib/render/threejs/three-material-generator.ts
@@ -18,7 +18,14 @@
  */
 
 import { RenderInfo } from '../../game/irenderable';
-import { BufferGeometry, Color, DoubleSide, Material as ThreeMaterial, MeshStandardMaterial } from '../../refs.node';
+import {
+	BufferGeometry,
+	Color,
+	DoubleSide,
+	LinearFilter, LinearMipMapLinearFilter, LinearMipMapNearestFilter,
+	Material as ThreeMaterial,
+	MeshStandardMaterial
+} from '../../refs.node';
 import { Material } from '../../vpt/material';
 import { MeshConvertOptions } from '../irender-api';
 import { ThreeMapGenerator } from './three-map-generator';

--- a/lib/render/threejs/three-material-generator.ts
+++ b/lib/render/threejs/three-material-generator.ts
@@ -22,7 +22,6 @@ import {
 	BufferGeometry,
 	Color,
 	DoubleSide,
-	LinearFilter, LinearMipMapLinearFilter, LinearMipMapNearestFilter,
 	Material as ThreeMaterial,
 	MeshStandardMaterial
 } from '../../refs.node';

--- a/lib/render/threejs/three-texture-loader-browser.ts
+++ b/lib/render/threejs/three-texture-loader-browser.ts
@@ -60,6 +60,7 @@ export class ThreeTextureLoaderBrowser implements ITextureLoader<ThreeTexture> {
 		const texture = await load(mimeType, objectUrl);
 		texture.name = `texture:${name}`;
 		texture.needsUpdate = true;
+		texture.anisotropy = 4;
 		return Promise.resolve(texture);
 	}
 }

--- a/lib/scripting/objects/pinball-backend/caching-service.spec.ts
+++ b/lib/scripting/objects/pinball-backend/caching-service.spec.ts
@@ -1,0 +1,53 @@
+/*
+ * VPDB - Virtual Pinball Database
+ * Copyright (C) 2019 freezy <freezy@vpdb.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import * as chai from 'chai';
+import { expect } from 'chai';
+import { CacheEntry, CacheType, EmulatorCachingService } from './caching-service';
+
+/* tslint:disable:no-unused-expression no-string-literal */
+chai.use(require('sinon-chai'));
+describe('EmulatorCache', () => {
+
+	let emulatorCache: EmulatorCachingService;
+
+	beforeEach(() => {
+		emulatorCache = new EmulatorCachingService();
+	});
+
+	it('add switch input to cache and retrieve it', () => {
+		const addedToCache = emulatorCache.cacheState(CacheType.SetSwitchInput, 42);
+		const result: CacheEntry[] = emulatorCache.getCache();
+
+		expect(addedToCache).to.equal(true);
+		expect(result).to.deep.equal([
+			{
+				cacheType: CacheType.SetSwitchInput,
+				valuee: 42
+			}
+		]);
+	});
+
+
+	it('should refuse to add entries to cache if already consumed', () => {
+		emulatorCache.getCache();
+		const addedToCache = emulatorCache.cacheState(CacheType.SetSwitchInput, 42);
+		expect(addedToCache).to.equal(false);
+	});
+});

--- a/lib/scripting/objects/pinball-backend/caching-service.spec.ts
+++ b/lib/scripting/objects/pinball-backend/caching-service.spec.ts
@@ -24,7 +24,7 @@ import { IEmulator } from '../../../game/iemulator';
 
 /* tslint:disable:no-unused-expression no-string-literal */
 chai.use(require('sinon-chai'));
-describe('EmulatorCache', () => {
+describe('The WPC-EMU emulator cache', () => {
 
 	let emulatorCache: EmulatorCachingService;
 	let mockEmulator: IEmulator;
@@ -36,7 +36,7 @@ describe('EmulatorCache', () => {
 		mockEmulator = new MockEmulator(cache);
 	});
 
-	it('add switch toggle to cache and apply it', () => {
+	it('should add switch toggle to cache and apply it', () => {
 		const addedToCache = emulatorCache.cacheState(CacheType.ToggleSwitchInput, 42);
 		emulatorCache.applyCache(mockEmulator);
 		expect(addedToCache).to.equal(true);
@@ -46,7 +46,7 @@ describe('EmulatorCache', () => {
 		}]);
 	});
 
-	it('add switch set to cache and apply it', () => {
+	it('should add switch set to cache and apply it', () => {
 		emulatorCache.cacheState(CacheType.SetSwitchInput, 42);
 		emulatorCache.applyCache(mockEmulator);
 		expect(cache).to.deep.equal([{
@@ -55,7 +55,7 @@ describe('EmulatorCache', () => {
 		}]);
 	});
 
-	it('add switch clear to cache and apply it', () => {
+	it('should add switch clear to cache and apply it', () => {
 		emulatorCache.cacheState(CacheType.ClearSwitchInput, 42);
 		emulatorCache.applyCache(mockEmulator);
 		expect(cache).to.deep.equal([{
@@ -64,7 +64,7 @@ describe('EmulatorCache', () => {
 		}]);
 	});
 
-	it('add cabinet input to cache and apply it', () => {
+	it('should add cabinet input to cache and apply it', () => {
 		emulatorCache.cacheState(CacheType.CabinetInput, 4);
 		emulatorCache.applyCache(mockEmulator);
 		expect(cache).to.deep.equal([{
@@ -72,7 +72,7 @@ describe('EmulatorCache', () => {
 		}]);
 	});
 
-	it('add execute ticks to cache and apply it', () => {
+	it('should add execute ticks to cache and apply it', () => {
 		emulatorCache.cacheState(CacheType.ExecuteTicks, 4);
 		emulatorCache.applyCache(mockEmulator);
 		expect(cache).to.deep.equal([{
@@ -80,7 +80,7 @@ describe('EmulatorCache', () => {
 		}]);
 	});
 
-	it('should warn when add entries to cache if already consumed', () => {
+	it('should should warn when add entries to cache if already consumed', () => {
 		emulatorCache.applyCache(mockEmulator);
 		const addedToCache = emulatorCache.cacheState(CacheType.SetSwitchInput, 42);
 		expect(addedToCache).to.equal(false);

--- a/lib/scripting/objects/pinball-backend/caching-service.spec.ts
+++ b/lib/scripting/objects/pinball-backend/caching-service.spec.ts
@@ -64,6 +64,14 @@ describe('EmulatorCache', () => {
 		}]);
 	});
 
+	it('add cabinet input to cache and apply it', () => {
+		emulatorCache.cacheState(CacheType.CabinetInput, 4);
+		emulatorCache.applyCache(mockEmulator);
+		expect(cache).to.deep.equal([{
+			keyNr: 4
+		}]);
+	});
+
 	it('should warn when add entries to cache if already consumed', () => {
 		emulatorCache.applyCache(mockEmulator);
 		const addedToCache = emulatorCache.cacheState(CacheType.SetSwitchInput, 42);
@@ -85,7 +93,7 @@ class MockEmulator implements IEmulator {
 		throw new Error("Method not implemented.");
 	}
 	setCabinetInput(keyNr: number): void {
-		throw new Error("Method not implemented.");
+		this.cache.push({keyNr});
 	}
 	setSwitchInput(switchNr: number, optionalEnableSwitch?: boolean): void {
 		this.cache.push({switchNr, optionalEnableSwitch});

--- a/lib/scripting/objects/pinball-backend/caching-service.spec.ts
+++ b/lib/scripting/objects/pinball-backend/caching-service.spec.ts
@@ -72,6 +72,14 @@ describe('EmulatorCache', () => {
 		}]);
 	});
 
+	it('add execute ticks to cache and apply it', () => {
+		emulatorCache.cacheState(CacheType.ExecuteTicks, 4);
+		emulatorCache.applyCache(mockEmulator);
+		expect(cache).to.deep.equal([{
+			dTime: 4
+		}]);
+	});
+
 	it('should warn when add entries to cache if already consumed', () => {
 		emulatorCache.applyCache(mockEmulator);
 		const addedToCache = emulatorCache.cacheState(CacheType.SetSwitchInput, 42);
@@ -85,8 +93,9 @@ class MockEmulator implements IEmulator {
 		this.cache = cache;
 	}
 	emuSimulateCycle(dTime: number): void {
-		throw new Error("Method not implemented.");
-	}	getDmdFrame(): Uint8Array {
+		this.cache.push({dTime});
+	}
+	getDmdFrame(): Uint8Array {
 		throw new Error("Method not implemented.");
 	}
 	getDmdDimensions(): import("../../../math/vertex2d").Vertex2D {

--- a/lib/scripting/objects/pinball-backend/caching-service.spec.ts
+++ b/lib/scripting/objects/pinball-backend/caching-service.spec.ts
@@ -36,10 +36,9 @@ describe('EmulatorCache', () => {
 		const result: CacheEntry[] = emulatorCache.getCache();
 
 		expect(addedToCache).to.equal(true);
-		expect(result).to.deep.equal([
-			{
+		expect(result).to.deep.equal([{
 				cacheType: CacheType.SetSwitchInput,
-				valuee: 42
+				value: 42
 			}
 		]);
 	});

--- a/lib/scripting/objects/pinball-backend/caching-service.spec.ts
+++ b/lib/scripting/objects/pinball-backend/caching-service.spec.ts
@@ -24,7 +24,7 @@ import { IEmulator } from '../../../game/iemulator';
 
 /* tslint:disable:no-unused-expression no-string-literal */
 chai.use(require('sinon-chai'));
-describe.only('EmulatorCache', () => {
+describe('EmulatorCache', () => {
 
 	let emulatorCache: EmulatorCachingService;
 	let mockEmulator: IEmulator;

--- a/lib/scripting/objects/pinball-backend/caching-service.ts
+++ b/lib/scripting/objects/pinball-backend/caching-service.ts
@@ -29,6 +29,7 @@ export enum CacheType {
 	SetSwitchInput = 1,
 	ClearSwitchInput,
 	ToggleSwitchInput,
+	CabinetInput,
 	ExecuteTicks,
 }
 
@@ -66,6 +67,8 @@ export class EmulatorCachingService {
 					return emulator.setSwitchInput(cacheEntry.value, false);
 				case CacheType.ToggleSwitchInput:
 					return emulator.setSwitchInput(cacheEntry.value);
+				case CacheType.CabinetInput:
+					return emulator.setCabinetInput(cacheEntry.value);
 				default:
 					logger().warn('UNKNOWN CACHE TYPE', cacheEntry.cacheType);
 			}

--- a/lib/scripting/objects/pinball-backend/caching-service.ts
+++ b/lib/scripting/objects/pinball-backend/caching-service.ts
@@ -54,22 +54,27 @@ export class EmulatorCachingService {
 	public applyCache(emulator: IEmulator): void {
 		this.clearedCache = true;
 		logger().debug('Apply cached commands to emu', this.cache.length);
-		this.cache.forEach((cacheEntry: CacheEntry) => {
+		for (const cacheEntry of this.cache) {
 			switch (cacheEntry.cacheType) {
 				case CacheType.SetSwitchInput:
-					return emulator.setSwitchInput(cacheEntry.value, true);
+					emulator.setSwitchInput(cacheEntry.value, true);
+					break;
 				case CacheType.ClearSwitchInput:
-					return emulator.setSwitchInput(cacheEntry.value, false);
+					emulator.setSwitchInput(cacheEntry.value, false);
+					break;
 				case CacheType.ToggleSwitchInput:
-					return emulator.setSwitchInput(cacheEntry.value);
+					emulator.setSwitchInput(cacheEntry.value);
+					break;
 				case CacheType.CabinetInput:
-					return emulator.setCabinetInput(cacheEntry.value);
+					emulator.setCabinetInput(cacheEntry.value);
+					break;
 				case CacheType.ExecuteTicks:
-					return emulator.emuSimulateCycle(cacheEntry.value);
+					emulator.emuSimulateCycle(cacheEntry.value);
+					break;
 				default:
 					logger().warn('UNKNOWN CACHE TYPE', cacheEntry.cacheType);
 			}
-		});
+		}
 	}
 }
 

--- a/lib/scripting/objects/pinball-backend/caching-service.ts
+++ b/lib/scripting/objects/pinball-backend/caching-service.ts
@@ -17,8 +17,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { logger } from '../../../util/logger';
 import { IEmulator } from '../../../game/iemulator';
+import { logger } from '../../../util/logger';
 
 /**
  * the VPX interface is sync, while our implementation is not when initializing

--- a/lib/scripting/objects/pinball-backend/caching-service.ts
+++ b/lib/scripting/objects/pinball-backend/caching-service.ts
@@ -20,6 +20,8 @@
 import { IEmulator } from '../../../game/iemulator';
 import { logger } from '../../../util/logger';
 
+// TODO caching is not exactly the correct term, come up with a better name!
+
 /**
  * the VPX interface is sync, while our implementation is not when initializing
  * This Caching Service caches all calls to the EMU while its initializing and
@@ -51,6 +53,7 @@ export class EmulatorCachingService {
 		return true;
 	}
 
+	// TODO replay messages as alternative?
 	public applyCache(emulator: IEmulator): void {
 		this.clearedCache = true;
 		logger().debug('Apply cached commands to emu', this.cache.length);

--- a/lib/scripting/objects/pinball-backend/caching-service.ts
+++ b/lib/scripting/objects/pinball-backend/caching-service.ts
@@ -1,0 +1,66 @@
+/*
+ * VPDB - Virtual Pinball Database
+ * Copyright (C) 2019 freezy <freezy@vpdb.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { logger } from '../../../util/logger';
+
+/**
+ * the VPX interface is sync, while our implementation is not when initializing
+ * This Caching Service caches all calls to the EMU while its initializing and
+ * allows to apply the changes once the emu is ready
+ */
+
+
+export enum CacheType {
+	SetSwitchInput = 1,
+	ExecuteTicks,
+}
+
+export class EmulatorCachingService {
+
+	private cache: CacheEntry[];
+	private clearedCache: boolean;
+
+	constructor() {
+		this.cache = [];
+		this.clearedCache = false;
+	}
+
+	/**
+	 * adds new cache entry
+	 * @returns true if entry was added to the cache, false if cache has already been consumed!
+	 */
+	public cacheState(cacheType: CacheType, value: number): boolean {
+		if (this.clearedCache) {
+			logger().warn('ADD STATE TO CLEARED CACHE! ENTRY WILL BE IGNORED!');
+			return false;
+		}
+		this.cache.push({ cacheType, value });
+		return true;
+	}
+
+	public getCache(): CacheEntry[] {
+		this.clearedCache = true;
+		return this.cache;
+	}
+}
+
+export interface CacheEntry {
+	cacheType: CacheType;
+	value: number;
+}

--- a/lib/scripting/objects/pinball-backend/caching-service.ts
+++ b/lib/scripting/objects/pinball-backend/caching-service.ts
@@ -69,6 +69,7 @@ export class EmulatorCachingService {
 					return emulator.setSwitchInput(cacheEntry.value);
 				case CacheType.CabinetInput:
 					return emulator.setCabinetInput(cacheEntry.value);
+				case CacheType.ExecuteTicks:
 				default:
 					logger().warn('UNKNOWN CACHE TYPE', cacheEntry.cacheType);
 			}

--- a/lib/scripting/objects/pinball-backend/caching-service.ts
+++ b/lib/scripting/objects/pinball-backend/caching-service.ts
@@ -70,6 +70,7 @@ export class EmulatorCachingService {
 				case CacheType.CabinetInput:
 					return emulator.setCabinetInput(cacheEntry.value);
 				case CacheType.ExecuteTicks:
+					return emulator.emuSimulateCycle(cacheEntry.value);
 				default:
 					logger().warn('UNKNOWN CACHE TYPE', cacheEntry.cacheType);
 			}

--- a/lib/scripting/objects/pinball-backend/caching-service.ts
+++ b/lib/scripting/objects/pinball-backend/caching-service.ts
@@ -35,13 +35,8 @@ export enum CacheType {
 
 export class EmulatorCachingService {
 
-	private cache: CacheEntry[];
-	private clearedCache: boolean;
-
-	constructor() {
-		this.cache = [];
-		this.clearedCache = false;
-	}
+	private readonly cache: CacheEntry[] = [];
+	private clearedCache: boolean = false;
 
 	/**
 	 * adds new cache entry

--- a/lib/scripting/objects/pinball-backend/emulator-state.spec.ts
+++ b/lib/scripting/objects/pinball-backend/emulator-state.spec.ts
@@ -83,13 +83,13 @@ describe('The EmulatorState - handle state changes', () => {
 
 	let emulatorState: EmulatorState;
 
-	const stateOne: WpcEmuWebWorkerApi.EmuState = {
+	const stateOne: WpcEmuWebWorkerApi.EmuStateAsic = {
 		ram: new Uint8Array(),
 		sound: soundState,
 		wpc: wpcState1,
 		dmd: dmdState,
 	};
-	const stateTwo: WpcEmuWebWorkerApi.EmuState = {
+	const stateTwo: WpcEmuWebWorkerApi.EmuStateAsic = {
 		ram: new Uint8Array(),
 		sound: soundState,
 		wpc: wpcState2,

--- a/lib/scripting/objects/pinball-backend/emulator-state.spec.ts
+++ b/lib/scripting/objects/pinball-backend/emulator-state.spec.ts
@@ -35,27 +35,6 @@ const dmdState: WpcEmuWebWorkerApi.EmuStateDMD = {
 	dmdPageMapping: [],
 };
 
-const wpcStateEmpty: WpcEmuWebWorkerApi.EmuStateWpc = {
-	diagnosticLed: 0,
-	lampState: new Uint8Array([]),
-	solenoidState: new Uint8Array([]),
-	generalIlluminationState: new Uint8Array([]),
-	inputState: new Uint8Array([]),
-	diagnosticLedToggleCount: 0,
-	midnightModeEnabled: false,
-	irqEnabled: false,
-	activeRomBank: 0,
-	time: 'fooTIME',
-	blankSignalHigh: false,
-	watchdogExpiredCounter: 0,
-	watchdogTicks: 0,
-	zeroCrossFlag: 0,
-	inputSwitchMatrixActiveColumn: new Uint8Array([]),
-	lampRow: 0,
-	lampColumn: 0,
-	wpcSecureScrambler: 0,
-};
-
 const wpcState1: WpcEmuWebWorkerApi.EmuStateWpc = {
 	diagnosticLed: 0,
 	lampState: new Uint8Array([1, 0, 0, 0, 0, 255, 127, 128]),
@@ -104,12 +83,6 @@ describe('The EmulatorState - handle state changes', () => {
 
 	let emulatorState: EmulatorState;
 
-	const stateEmpty: WpcEmuWebWorkerApi.EmuState = {
-		ram: new Uint8Array(),
-		sound: soundState,
-		wpc: wpcStateEmpty,
-		dmd: dmdState,
-	};
 	const stateOne: WpcEmuWebWorkerApi.EmuState = {
 		ram: new Uint8Array(),
 		sound: soundState,
@@ -131,6 +104,14 @@ describe('The EmulatorState - handle state changes', () => {
 		expect(emulatorState.getChangedLamps()).to.deep.equal([]);
 	});
 
+	it('transition initial getChangedSolenoids() should return empty array', () => {
+		expect(emulatorState.getChangedSolenoids()).to.deep.equal([]);
+	});
+
+	it('transition initial getChangedGI() should return empty array', () => {
+		expect(emulatorState.getChangedGI()).to.deep.equal([]);
+	});
+
 	it('transition empty state -> state 1', () => {
 		const expectedDiff: number[][] = [
 			[ 0, 0 ],
@@ -143,6 +124,35 @@ describe('The EmulatorState - handle state changes', () => {
 			[ 7, 1 ],
 		];
 		emulatorState.updateState(stateOne);
+		const result: number[][] = emulatorState.getChangedLamps();
+		expect(result).to.deep.equal(expectedDiff);
+	});
+
+	it('transition state 1 -> state 2', () => {
+		const expectedDiff: number[][] = [
+			[ 5, 0 ],
+			[ 7, 0 ],
+		];
+		emulatorState.updateState(stateOne);
+		emulatorState.getChangedLamps();
+		emulatorState.updateState(stateTwo);
+		const result: number[][] = emulatorState.getChangedLamps();
+		expect(result).to.deep.equal(expectedDiff);
+	});
+
+	it('transition empty state -> state 1 -> state 2, without fetching state', () => {
+		const expectedDiff: number[][] = [
+			[ 0, 0 ],
+			[ 1, 0 ],
+			[ 2, 0 ],
+			[ 3, 0 ],
+			[ 4, 0 ],
+			[ 5, 0 ],
+			[ 6, 0 ],
+			[ 7, 0 ],
+		];
+		emulatorState.updateState(stateOne);
+		emulatorState.updateState(stateTwo);
 		const result: number[][] = emulatorState.getChangedLamps();
 		expect(result).to.deep.equal(expectedDiff);
 	});

--- a/lib/scripting/objects/pinball-backend/emulator-state.spec.ts
+++ b/lib/scripting/objects/pinball-backend/emulator-state.spec.ts
@@ -114,14 +114,14 @@ describe('The EmulatorState - handle state changes', () => {
 
 	it('transition empty state -> state 1', () => {
 		const expectedDiff: number[][] = [
-			[ 1, 0 ],
-			[ 2, 0 ],
-			[ 3, 0 ],
-			[ 4, 0 ],
-			[ 5, 0 ],
-			[ 6, 1 ],
-			[ 7, 0 ],
-			[ 8, 1 ],
+			[ 11, 0 ],
+			[ 12, 0 ],
+			[ 13, 0 ],
+			[ 14, 0 ],
+			[ 15, 0 ],
+			[ 16, 1 ],
+			[ 17, 0 ],
+			[ 18, 1 ],
 		];
 		emulatorState.updateState(stateOne);
 		const result: number[][] = emulatorState.getChangedLamps();
@@ -130,8 +130,8 @@ describe('The EmulatorState - handle state changes', () => {
 
 	it('transition state 1 -> state 2', () => {
 		const expectedDiff: number[][] = [
-			[ 6, 0 ],
-			[ 8, 0 ],
+			[ 16, 0 ],
+			[ 18, 0 ],
 		];
 		emulatorState.updateState(stateOne);
 		emulatorState.getChangedLamps();
@@ -142,14 +142,14 @@ describe('The EmulatorState - handle state changes', () => {
 
 	it('transition empty state -> state 1 -> state 2, without fetching state', () => {
 		const expectedDiff: number[][] = [
-			[ 1, 0 ],
-			[ 2, 0 ],
-			[ 3, 0 ],
-			[ 4, 0 ],
-			[ 5, 0 ],
-			[ 6, 0 ],
-			[ 7, 0 ],
-			[ 8, 0 ],
+			[ 11, 0 ],
+			[ 12, 0 ],
+			[ 13, 0 ],
+			[ 14, 0 ],
+			[ 15, 0 ],
+			[ 16, 0 ],
+			[ 17, 0 ],
+			[ 18, 0 ],
 		];
 		emulatorState.updateState(stateOne);
 		emulatorState.updateState(stateTwo);

--- a/lib/scripting/objects/pinball-backend/emulator-state.spec.ts
+++ b/lib/scripting/objects/pinball-backend/emulator-state.spec.ts
@@ -100,7 +100,7 @@ const wpcState2: WpcEmuWebWorkerApi.EmuStateWpc = {
 
 /* tslint:disable:no-unused-expression no-string-literal */
 chai.use(require('sinon-chai'));
-describe.only('The EmulatorState - handle state changes', () => {
+describe('The EmulatorState - handle state changes', () => {
 
 	let emulatorState: EmulatorState;
 

--- a/lib/scripting/objects/pinball-backend/emulator-state.spec.ts
+++ b/lib/scripting/objects/pinball-backend/emulator-state.spec.ts
@@ -58,10 +58,10 @@ const wpcStateEmpty: WpcEmuWebWorkerApi.EmuStateWpc = {
 
 const wpcState1: WpcEmuWebWorkerApi.EmuStateWpc = {
 	diagnosticLed: 0,
-	lampState: new Uint8Array([1, 0, 0, 0, 0, 0, 0, 0]),
-	solenoidState: new Uint8Array([2, 0, 0, 0, 0, 0, 0, 0]),
-	generalIlluminationState: new Uint8Array([3, 0, 0, 0, 0, 0, 0, 0]),
-	inputState: new Uint8Array([4, 0, 0, 0, 0, 0, 0, 0]),
+	lampState: new Uint8Array([1, 0, 0, 0, 0, 255, 127, 128]),
+	solenoidState: new Uint8Array([2, 0, 0, 0, 0, 255, 127, 128]),
+	generalIlluminationState: new Uint8Array([3, 0, 0, 0, 0, 255, 127, 128]),
+	inputState: new Uint8Array([4, 0, 0, 0, 0, 255, 127, 128]),
 	diagnosticLedToggleCount: 0,
 	midnightModeEnabled: false,
 	irqEnabled: false,
@@ -71,7 +71,7 @@ const wpcState1: WpcEmuWebWorkerApi.EmuStateWpc = {
 	watchdogExpiredCounter: 0,
 	watchdogTicks: 0,
 	zeroCrossFlag: 0,
-	inputSwitchMatrixActiveColumn: new Uint8Array([5, 0, 0, 0, 0, 0, 0, 0]),
+	inputSwitchMatrixActiveColumn: new Uint8Array([5, 0, 0, 0, 0, 255, 127, 128]),
 	lampRow: 0,
 	lampColumn: 0,
 	wpcSecureScrambler: 0,
@@ -110,13 +110,13 @@ describe('The EmulatorState - handle state changes', () => {
 		wpc: wpcStateEmpty,
 		dmd: dmdState,
 	};
-	const stateZero: WpcEmuWebWorkerApi.EmuState = {
+	const stateOne: WpcEmuWebWorkerApi.EmuState = {
 		ram: new Uint8Array(),
 		sound: soundState,
 		wpc: wpcState1,
 		dmd: dmdState,
 	};
-	const stateOne: WpcEmuWebWorkerApi.EmuState = {
+	const stateTwo: WpcEmuWebWorkerApi.EmuState = {
 		ram: new Uint8Array(),
 		sound: soundState,
 		wpc: wpcState2,
@@ -133,21 +133,22 @@ describe('The EmulatorState - handle state changes', () => {
 
 	it('transition empty state -> state 1', () => {
 		const expectedDiff: number[][] = [
-			[ 0, 1 ],
+			[ 0, 0 ],
 			[ 1, 0 ],
 			[ 2, 0 ],
 			[ 3, 0 ],
 			[ 4, 0 ],
-			[ 5, 0 ],
+			[ 5, 1 ],
 			[ 6, 0 ],
-			[ 7, 0 ]
+			[ 7, 1 ],
 		];
-		emulatorState.updateState(stateZero);
-		expect(emulatorState.getChangedLamps()).to.deep.equal(expectedDiff);
+		emulatorState.updateState(stateOne);
+		const result: number[][] = emulatorState.getChangedLamps();
+		expect(result).to.deep.equal(expectedDiff);
 	});
 
 	it('transition multiple getChangedLamps() calls without state update should return empty array', () => {
-		emulatorState.updateState(stateZero);
+		emulatorState.updateState(stateOne);
 		emulatorState.getChangedLamps();
 		expect(emulatorState.getChangedLamps()).to.deep.equal([]);
 	});

--- a/lib/scripting/objects/pinball-backend/emulator-state.spec.ts
+++ b/lib/scripting/objects/pinball-backend/emulator-state.spec.ts
@@ -1,0 +1,155 @@
+/*
+ * VPDB - Virtual Pinball Database
+ * Copyright (C) 2019 freezy <freezy@vpdb.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import * as chai from 'chai';
+import { expect } from 'chai';
+import { WpcEmuWebWorkerApi } from 'wpc-emu';
+import { EmulatorState } from './emulator-state';
+
+const soundState: WpcEmuWebWorkerApi.EmuStateSound = {
+	volume: 0,
+	readDataBytes: 0,
+	writeDataBytes: 0,
+	readControlBytes: 0,
+	writeControlBytes: 0,
+};
+
+const dmdState: WpcEmuWebWorkerApi.EmuStateDMD = {
+	scanline: 0,
+	dmdPageMapping: [],
+};
+
+const wpcStateEmpty: WpcEmuWebWorkerApi.EmuStateWpc = {
+	diagnosticLed: 0,
+	lampState: new Uint8Array([]),
+	solenoidState: new Uint8Array([]),
+	generalIlluminationState: new Uint8Array([]),
+	inputState: new Uint8Array([]),
+	diagnosticLedToggleCount: 0,
+	midnightModeEnabled: false,
+	irqEnabled: false,
+	activeRomBank: 0,
+	time: 'fooTIME',
+	blankSignalHigh: false,
+	watchdogExpiredCounter: 0,
+	watchdogTicks: 0,
+	zeroCrossFlag: 0,
+	inputSwitchMatrixActiveColumn: new Uint8Array([]),
+	lampRow: 0,
+	lampColumn: 0,
+	wpcSecureScrambler: 0,
+};
+
+const wpcState1: WpcEmuWebWorkerApi.EmuStateWpc = {
+	diagnosticLed: 0,
+	lampState: new Uint8Array([1, 0, 0, 0, 0, 0, 0, 0]),
+	solenoidState: new Uint8Array([2, 0, 0, 0, 0, 0, 0, 0]),
+	generalIlluminationState: new Uint8Array([3, 0, 0, 0, 0, 0, 0, 0]),
+	inputState: new Uint8Array([4, 0, 0, 0, 0, 0, 0, 0]),
+	diagnosticLedToggleCount: 0,
+	midnightModeEnabled: false,
+	irqEnabled: false,
+	activeRomBank: 0,
+	time: 'fooTIME1',
+	blankSignalHigh: false,
+	watchdogExpiredCounter: 0,
+	watchdogTicks: 0,
+	zeroCrossFlag: 0,
+	inputSwitchMatrixActiveColumn: new Uint8Array([5, 0, 0, 0, 0, 0, 0, 0]),
+	lampRow: 0,
+	lampColumn: 0,
+	wpcSecureScrambler: 0,
+};
+
+const wpcState2: WpcEmuWebWorkerApi.EmuStateWpc = {
+	diagnosticLed: 1,
+	lampState: new Uint8Array([1, 0, 0, 0, 0, 0, 0, 0]),
+	solenoidState: new Uint8Array([2, 0, 0, 0, 0, 0, 0, 0]),
+	generalIlluminationState: new Uint8Array([3, 0, 0, 0, 0, 0, 0, 0]),
+	inputState: new Uint8Array([4, 0, 0, 0, 0, 0, 0, 0]),
+	diagnosticLedToggleCount: 1,
+	midnightModeEnabled: true,
+	irqEnabled: true,
+	activeRomBank: 1,
+	time: 'fooTIME2',
+	blankSignalHigh: true,
+	watchdogExpiredCounter: 1,
+	watchdogTicks: 1,
+	zeroCrossFlag: 1,
+	inputSwitchMatrixActiveColumn: new Uint8Array([5, 0, 0, 0, 0, 0, 0, 0]),
+	lampRow: 1,
+	lampColumn: 1,
+	wpcSecureScrambler: 1,
+};
+
+/* tslint:disable:no-unused-expression no-string-literal */
+chai.use(require('sinon-chai'));
+describe.only('The EmulatorState - handle state changes', () => {
+
+	let emulatorState: EmulatorState;
+
+	const stateEmpty: WpcEmuWebWorkerApi.EmuState = {
+		ram: new Uint8Array(),
+		sound: soundState,
+		wpc: wpcStateEmpty,
+		dmd: dmdState,
+	};
+	const stateZero: WpcEmuWebWorkerApi.EmuState = {
+		ram: new Uint8Array(),
+		sound: soundState,
+		wpc: wpcState1,
+		dmd: dmdState,
+	};
+	const stateOne: WpcEmuWebWorkerApi.EmuState = {
+		ram: new Uint8Array(),
+		sound: soundState,
+		wpc: wpcState2,
+		dmd: dmdState,
+	};
+
+	beforeEach(() => {
+		emulatorState = new EmulatorState();
+	});
+
+	it('transition initial getChangedLamps() should return empty array', () => {
+		expect(emulatorState.getChangedLamps()).to.deep.equal([]);
+	});
+
+	it('transition empty state -> state 1', () => {
+		const expectedDiff: number[][] = [
+			[ 0, 1 ],
+			[ 1, 0 ],
+			[ 2, 0 ],
+			[ 3, 0 ],
+			[ 4, 0 ],
+			[ 5, 0 ],
+			[ 6, 0 ],
+			[ 7, 0 ]
+		];
+		emulatorState.updateState(stateZero);
+		expect(emulatorState.getChangedLamps()).to.deep.equal(expectedDiff);
+	});
+
+	it('transition multiple getChangedLamps() calls without state update should return empty array', () => {
+		emulatorState.updateState(stateZero);
+		emulatorState.getChangedLamps();
+		expect(emulatorState.getChangedLamps()).to.deep.equal([]);
+	});
+
+});

--- a/lib/scripting/objects/pinball-backend/emulator-state.spec.ts
+++ b/lib/scripting/objects/pinball-backend/emulator-state.spec.ts
@@ -115,13 +115,7 @@ describe('The EmulatorState - handle state changes', () => {
 
 	it('transition empty state -> state 1', () => {
 		const expectedDiff: number[][] = [
-			[ 11, 0 ],
-			[ 12, 0 ],
-			[ 13, 0 ],
-			[ 14, 0 ],
-			[ 15, 0 ],
 			[ 16, 1 ],
-			[ 17, 0 ],
 			[ 18, 1 ],
 		];
 		emulatorState.updateState(stateOne);
@@ -142,20 +136,10 @@ describe('The EmulatorState - handle state changes', () => {
 	});
 
 	it('transition empty state -> state 1 -> state 2, without fetching state', () => {
-		const expectedDiff: number[][] = [
-			[ 11, 0 ],
-			[ 12, 0 ],
-			[ 13, 0 ],
-			[ 14, 0 ],
-			[ 15, 0 ],
-			[ 16, 0 ],
-			[ 17, 0 ],
-			[ 18, 0 ],
-		];
 		emulatorState.updateState(stateOne);
 		emulatorState.updateState(stateTwo);
 		const result: number[][] = emulatorState.getChangedLamps();
-		expect(result).to.deep.equal(expectedDiff);
+		expect(result).to.deep.equal([]);
 	});
 
 	it('transition multiple getChangedLamps() calls without state update should return empty array', () => {

--- a/lib/scripting/objects/pinball-backend/emulator-state.spec.ts
+++ b/lib/scripting/objects/pinball-backend/emulator-state.spec.ts
@@ -101,19 +101,19 @@ describe('The EmulatorState - handle state changes', () => {
 		emulatorState = new EmulatorState();
 	});
 
-	it('transition initial getChangedLamps() should return empty array', () => {
+	it('should return empty array for initially unchanged lamps', () => {
 		expect(emulatorState.getChangedLamps()).to.deep.equal([]);
 	});
 
-	it('transition initial getChangedSolenoids() should return empty array', () => {
+	it('should return empty array for initially unchanged solenoids', () => {
 		expect(emulatorState.getChangedSolenoids()).to.deep.equal([]);
 	});
 
-	it('transition initial getChangedGI() should return empty array', () => {
+	it('should return empty array for initially unchanged GI strings', () => {
 		expect(emulatorState.getChangedGI()).to.deep.equal([]);
 	});
 
-	it('transition empty state -> state 1', () => {
+	it('should get changed lamps when transition from empty state to state 1', () => {
 		const expectedDiff: number[][] = [
 			[ 16, 1 ],
 			[ 18, 1 ],
@@ -123,7 +123,7 @@ describe('The EmulatorState - handle state changes', () => {
 		expect(result).to.deep.equal(expectedDiff);
 	});
 
-	it('transition state 1 -> state 2', () => {
+	it('should get changed lamps when transition from state 1 to state 2', () => {
 		const expectedDiff: number[][] = [
 			[ 16, 0 ],
 			[ 18, 0 ],
@@ -135,25 +135,25 @@ describe('The EmulatorState - handle state changes', () => {
 		expect(result).to.deep.equal(expectedDiff);
 	});
 
-	it('transition empty state -> state 1 -> state 2, without fetching state', () => {
+	it('should return empty array when transition from empty state -> state 1 -> state 2, without fetching state', () => {
 		emulatorState.updateState(stateOne);
 		emulatorState.updateState(stateTwo);
 		const result: number[][] = emulatorState.getChangedLamps();
 		expect(result).to.deep.equal([]);
 	});
 
-	it('transition multiple getChangedLamps() calls without state update should return empty array', () => {
+	it('should return empty array after calling multiple getChangedLamps()', () => {
 		emulatorState.updateState(stateOne);
 		emulatorState.getChangedLamps();
 		expect(emulatorState.getChangedLamps()).to.deep.equal([]);
 	});
 
-	it('get ChangedLEDs - not implemented used for Alphanumeric displays only', () => {
+	it('should return empty array after fetching ChangedLEDs - not implemented used for Alphanumeric displays only', () => {
 		const result: number[][] = emulatorState.ChangedLEDs();
 		expect(result).to.deep.equal([]);
 	});
 
-	it('get empty getDmdScreen', () => {
+	it('should get empty getDmdScreen', () => {
 		const result: Uint8Array = emulatorState.getDmdScreen();
 		expect(result.length).to.equal(0);
 	});

--- a/lib/scripting/objects/pinball-backend/emulator-state.spec.ts
+++ b/lib/scripting/objects/pinball-backend/emulator-state.spec.ts
@@ -32,6 +32,7 @@ const soundState: WpcEmuWebWorkerApi.EmuStateSound = {
 
 const dmdState: WpcEmuWebWorkerApi.EmuStateDMD = {
 	scanline: 0,
+	dmdShadedBuffer: new Uint8Array([1,2,3]),
 	dmdPageMapping: [],
 };
 
@@ -161,6 +162,16 @@ describe('The EmulatorState - handle state changes', () => {
 		emulatorState.updateState(stateOne);
 		emulatorState.getChangedLamps();
 		expect(emulatorState.getChangedLamps()).to.deep.equal([]);
+	});
+
+	it('get ChangedLEDs - not implemented used for Alphanumeric displays only', () => {
+		const result: number[][] = emulatorState.ChangedLEDs();
+		expect(result).to.deep.equal([]);
+	});
+
+	it('get empty getDmdScreen', () => {
+		const result: Uint8Array = emulatorState.getDmdScreen();
+		expect(result.length).to.equal(0);
 	});
 
 });

--- a/lib/scripting/objects/pinball-backend/emulator-state.spec.ts
+++ b/lib/scripting/objects/pinball-backend/emulator-state.spec.ts
@@ -114,14 +114,14 @@ describe('The EmulatorState - handle state changes', () => {
 
 	it('transition empty state -> state 1', () => {
 		const expectedDiff: number[][] = [
-			[ 0, 0 ],
 			[ 1, 0 ],
 			[ 2, 0 ],
 			[ 3, 0 ],
 			[ 4, 0 ],
-			[ 5, 1 ],
-			[ 6, 0 ],
-			[ 7, 1 ],
+			[ 5, 0 ],
+			[ 6, 1 ],
+			[ 7, 0 ],
+			[ 8, 1 ],
 		];
 		emulatorState.updateState(stateOne);
 		const result: number[][] = emulatorState.getChangedLamps();
@@ -130,8 +130,8 @@ describe('The EmulatorState - handle state changes', () => {
 
 	it('transition state 1 -> state 2', () => {
 		const expectedDiff: number[][] = [
-			[ 5, 0 ],
-			[ 7, 0 ],
+			[ 6, 0 ],
+			[ 8, 0 ],
 		];
 		emulatorState.updateState(stateOne);
 		emulatorState.getChangedLamps();
@@ -142,7 +142,6 @@ describe('The EmulatorState - handle state changes', () => {
 
 	it('transition empty state -> state 1 -> state 2, without fetching state', () => {
 		const expectedDiff: number[][] = [
-			[ 0, 0 ],
 			[ 1, 0 ],
 			[ 2, 0 ],
 			[ 3, 0 ],
@@ -150,6 +149,7 @@ describe('The EmulatorState - handle state changes', () => {
 			[ 5, 0 ],
 			[ 6, 0 ],
 			[ 7, 0 ],
+			[ 8, 0 ],
 		];
 		emulatorState.updateState(stateOne);
 		emulatorState.updateState(stateTwo);

--- a/lib/scripting/objects/pinball-backend/emulator-state.ts
+++ b/lib/scripting/objects/pinball-backend/emulator-state.ts
@@ -63,14 +63,15 @@ export class EmulatorState {
 	}
 
 	public getSwitchState(index: number): number {
-		return this.switchState[index];
+		const matrixIndex: number = mapIndexToMatrixIndex(index);
+		return this.switchState[matrixIndex];
 	}
 
 	/**
 	 * return changed lamps, index starts at 11..18, 21..28.. up to index 88
 	 */
 	public getChangedLamps(): number[][] {
-		const result: number[][] = this.getArrayDiff(this.lastSentLampState, this.currentLampState, mapIndexToLampIndex);
+		const result: number[][] = this.getArrayDiff(this.lastSentLampState, this.currentLampState, mapIndexToMatrixIndex);
 		this.lastSentLampState = this.currentLampState;
 		return result;
 	}
@@ -126,7 +127,7 @@ export class EmulatorState {
 	}
 }
 
-function mapIndexToLampIndex(index: number): number {
+function mapIndexToMatrixIndex(index: number): number {
 	const row = Math.floor(index / 8);
 	const column = Math.floor(index % 8);
 	return 10 * row + 11 + column;

--- a/lib/scripting/objects/pinball-backend/emulator-state.ts
+++ b/lib/scripting/objects/pinball-backend/emulator-state.ts
@@ -22,17 +22,17 @@ import { logger } from '../../../util/logger';
 
 export class EmulatorState {
 
-	private lastKnownLampState: Uint8Array;
 	private currentLampState: Uint8Array;
-	private lastKnownSolenoidState: Uint8Array;
 	private currentSolenoidState: Uint8Array;
-	private lastKnownGIState: Uint8Array;
 	private currentGIState: Uint8Array;
+	private lastSentLampState: Uint8Array;
+	private lastSentSolenoidState: Uint8Array;
+	private lastSentGIState: Uint8Array;
 
 	constructor() {
-		this.lastKnownLampState = new Uint8Array();
-		this.lastKnownSolenoidState = new Uint8Array();
-		this.lastKnownGIState = new Uint8Array();
+		this.lastSentLampState = new Uint8Array();
+		this.lastSentSolenoidState = new Uint8Array();
+		this.lastSentGIState = new Uint8Array();
 		this.currentLampState = new Uint8Array();
 		this.currentSolenoidState = new Uint8Array();
 		this.currentGIState = new Uint8Array();
@@ -51,20 +51,20 @@ export class EmulatorState {
 	}
 
 	public getChangedLamps(): number[][] {
-		const result: number[][] = this.getArrayDiff(this.lastKnownLampState, this.currentLampState);
-		this.lastKnownLampState = this.currentLampState;
+		const result: number[][] = this.getArrayDiff(this.lastSentLampState, this.currentLampState);
+		this.lastSentLampState = this.currentLampState;
 		return result;
 	}
 
 	public getChangedSolenoids(): number[][] {
-		const result: number[][] = this.getArrayDiff(this.lastKnownSolenoidState, this.currentSolenoidState);
-		this.lastKnownSolenoidState = this.currentSolenoidState;
+		const result: number[][] = this.getArrayDiff(this.lastSentSolenoidState, this.currentSolenoidState);
+		this.lastSentSolenoidState = this.currentSolenoidState;
 		return result;
 	}
 
 	public getChangedGI(): number[][] {
-		const result: number[][] = this.getArrayDiff(this.lastKnownSolenoidState, this.currentGIState);
-		this.lastKnownGIState = this.currentGIState;
+		const result: number[][] = this.getArrayDiff(this.lastSentGIState, this.currentGIState);
+		this.lastSentGIState = this.currentGIState;
 		return result;
 	}
 
@@ -90,10 +90,9 @@ export class EmulatorState {
 			return result;
 		}
 		for (let n: number = 0; n < newState.length; n++) {
-			if (lastState[n] === newState[n]) {
-				continue;
+			if (lastState[n] !== newState[n]) {
+				result.push([n, newState[n]]);
 			}
-			result.push([n, newState[n]]);
 		}
 		return result;
 	}

--- a/lib/scripting/objects/pinball-backend/emulator-state.ts
+++ b/lib/scripting/objects/pinball-backend/emulator-state.ts
@@ -17,8 +17,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { logger } from '../../../util/logger';
 import { WpcEmuWebWorkerApi } from 'wpc-emu';
+import { logger } from '../../../util/logger';
 
 export class EmulatorState {
 
@@ -28,7 +28,10 @@ export class EmulatorState {
 	private lastKnownGIState: Uint8Array;
 
 	constructor() {
-		this.clearState();
+		this.lastKnownState = undefined;
+		this.lastKnownLampState = new Uint8Array();
+		this.lastKnownSolenoidState = new Uint8Array();
+		this.lastKnownGIState = new Uint8Array();
 	}
 
 	public clearState() {
@@ -77,7 +80,36 @@ export class EmulatorState {
 		return [];
 	}
 
+	/**
+	 * diff between two arrays equally sized arrays
+	 * returns 2 dimensional array with the result, eg [0, 5], [4, 44] -> means entry at offset 0 changed to 5, entry at offset 4 changed to 44
+	 */
 	private getArrayDiff(lastState: Uint8Array, newState: Uint8Array): number[][] {
-		return [];
+		const result: number[][] = [];
+		if (arraysEqual(lastState, newState)) {
+			return result;
+		}
+		for (let n: number = 0; n < newState.length; n++) {
+			if (lastState[n] === newState[n]) {
+				continue;
+			}
+			result.push([n, newState[n]]);
+		}
+		return result;
 	}
+}
+
+function arraysEqual(a: Uint8Array, b: Uint8Array): boolean {
+	if (a === b) {
+		return true;
+	}
+	if (!a || !b || a.length !== b.length) {
+		return false;
+	}
+	for (let i = 0; i < a.length; ++i) {
+		if (a[i] !== b[i]) {
+			return false;
+		}
+	}
+	return true;
 }

--- a/lib/scripting/objects/pinball-backend/emulator-state.ts
+++ b/lib/scripting/objects/pinball-backend/emulator-state.ts
@@ -28,25 +28,14 @@ function getEmptyUint8Array(size: number = 64) {
  */
 export class EmulatorState {
 
-	private currentLampState: Uint8Array;
-	private currentSolenoidState: Uint8Array;
-	private currentGIState: Uint8Array;
-	private lastSentLampState: Uint8Array;
-	private lastSentSolenoidState: Uint8Array;
-	private lastSentGIState: Uint8Array;
-	private dmdScreen: Uint8Array;
-	private switchState: Uint8Array;
-
-	constructor() {
-		this.lastSentLampState = getEmptyUint8Array();
-		this.lastSentSolenoidState = getEmptyUint8Array();
-		this.lastSentGIState = getEmptyUint8Array();
-		this.currentLampState = getEmptyUint8Array();
-		this.currentSolenoidState = getEmptyUint8Array();
-		this.currentGIState = getEmptyUint8Array();
-		this.dmdScreen = new Uint8Array();
-		this.switchState = new Uint8Array();
-	}
+	private currentLampState: Uint8Array = getEmptyUint8Array();
+	private currentSolenoidState: Uint8Array = getEmptyUint8Array();
+	private currentGIState: Uint8Array = getEmptyUint8Array();
+	private lastSentLampState: Uint8Array = getEmptyUint8Array();
+	private lastSentSolenoidState: Uint8Array = getEmptyUint8Array();
+	private lastSentGIState: Uint8Array = getEmptyUint8Array();
+	private dmdScreen: Uint8Array = new Uint8Array();
+	private switchState: Uint8Array = new Uint8Array();
 
 	public updateState(state: WpcEmuWebWorkerApi.EmuStateAsic) {
 		if (state.wpc.lampState) {
@@ -134,9 +123,6 @@ export class EmulatorState {
 	 */
 	private getArrayDiff(lastState: Uint8Array, newState: Uint8Array, offsetMapperFunction: (index: number) => number): number[][] {
 		const result: number[][] = [];
-		if (arraysEqual(lastState, newState)) {
-			return result;
-		}
 		for (let n: number = 0; n < newState.length; n++) {
 			if (lastState[n] !== newState[n]) {
 				const index = offsetMapperFunction(n);
@@ -155,19 +141,4 @@ function mapIndexToMatrixIndex(index: number): number {
 
 function mapIndexToOneBasedIndex(index: number): number {
 	return index + 1;
-}
-
-function arraysEqual(a: Uint8Array, b: Uint8Array): boolean {
-	if (a === b) {
-		return true;
-	}
-	if (!a || !b || a.length !== b.length) {
-		return false;
-	}
-	for (let i = 0; i < a.length; ++i) {
-		if (a[i] !== b[i]) {
-			return false;
-		}
-	}
-	return true;
 }

--- a/lib/scripting/objects/pinball-backend/emulator-state.ts
+++ b/lib/scripting/objects/pinball-backend/emulator-state.ts
@@ -28,6 +28,7 @@ export class EmulatorState {
 	private lastSentLampState: Uint8Array;
 	private lastSentSolenoidState: Uint8Array;
 	private lastSentGIState: Uint8Array;
+	private dmdScreen: Uint8Array;
 
 	constructor() {
 		this.lastSentLampState = new Uint8Array();
@@ -36,6 +37,7 @@ export class EmulatorState {
 		this.currentLampState = new Uint8Array();
 		this.currentSolenoidState = new Uint8Array();
 		this.currentGIState = new Uint8Array();
+		this.dmdScreen = new Uint8Array();
 	}
 
 	public updateState(state: WpcEmuWebWorkerApi.EmuStateAsic) {
@@ -47,6 +49,9 @@ export class EmulatorState {
 		}
 		if (state.wpc.generalIlluminationState) {
 			this.currentGIState = state.wpc.generalIlluminationState;
+		}
+		if (state.dmd.dmdShadedBuffer) {
+			this.dmdScreen = state.dmd.dmdShadedBuffer;
 		}
 	}
 
@@ -71,6 +76,10 @@ export class EmulatorState {
 	// NOT IMPLEMENTED YET - needed for alphanumeric games only!
 	public ChangedLEDs(): number[][] {
 		return [];
+	}
+
+	public getDmdScreen(): Uint8Array {
+		return this.dmdScreen;
 	}
 
 	/**

--- a/lib/scripting/objects/pinball-backend/emulator-state.ts
+++ b/lib/scripting/objects/pinball-backend/emulator-state.ts
@@ -18,7 +18,6 @@
  */
 
 import { WpcEmuWebWorkerApi } from 'wpc-emu';
-import { logger } from '../../../util/logger';
 
 function getEmptyUint8Array(size: number = 64) {
 	return new Uint8Array(size).fill(0);

--- a/lib/scripting/objects/pinball-backend/emulator-state.ts
+++ b/lib/scripting/objects/pinball-backend/emulator-state.ts
@@ -91,7 +91,8 @@ export class EmulatorState {
 		}
 		for (let n: number = 0; n < newState.length; n++) {
 			if (lastState[n] !== newState[n]) {
-				result.push([n, newState[n]]);
+				// NOTE: the first entry has index 1 and not 0!
+				result.push([n + 1, newState[n]]);
 			}
 		}
 		return result;

--- a/lib/scripting/objects/pinball-backend/emulator-state.ts
+++ b/lib/scripting/objects/pinball-backend/emulator-state.ts
@@ -23,16 +23,61 @@ import { WpcEmuWebWorkerApi } from 'wpc-emu';
 export class EmulatorState {
 
 	private lastKnownState?: WpcEmuWebWorkerApi.EmuState;
+	private lastKnownLampState: Uint8Array;
+	private lastKnownSolenoidState: Uint8Array;
+	private lastKnownGIState: Uint8Array;
 
 	constructor() {
-		this.lastKnownState = undefined;
+		this.clearState();
 	}
 
-	updateState(state: WpcEmuWebWorkerApi.EmuState) {
+	public clearState() {
+		this.lastKnownState = undefined;
+		this.lastKnownLampState = new Uint8Array();
+		this.lastKnownSolenoidState = new Uint8Array();
+		this.lastKnownGIState = new Uint8Array();
+	}
+
+	public updateState(state: WpcEmuWebWorkerApi.EmuState) {
 		this.lastKnownState = state;
 	}
 
-	getChangedLamps(): void {
-		//TODO
+	public getChangedLamps(): number[][] {
+		if (!this.lastKnownState || !this.lastKnownState.wpc.lampState) {
+			return [];
+		}
+
+		const result: number[][] = this.getArrayDiff(this.lastKnownLampState, this.lastKnownState.wpc.lampState);
+		this.lastKnownLampState = this.lastKnownState.wpc.lampState;
+		return result;
+	}
+
+	public getChangedSolenoids(): number[][] {
+		if (!this.lastKnownState || !this.lastKnownState.wpc.solenoidState) {
+			return [];
+		}
+
+		const result: number[][] = this.getArrayDiff(this.lastKnownSolenoidState, this.lastKnownState.wpc.solenoidState);
+		this.lastKnownSolenoidState = this.lastKnownState.wpc.solenoidState;
+		return result;
+	}
+
+	public getChangedGI(): number[][] {
+		if (!this.lastKnownState || !this.lastKnownState.wpc.generalIlluminationState) {
+			return [];
+		}
+
+		const result: number[][] = this.getArrayDiff(this.lastKnownSolenoidState, this.lastKnownState.wpc.generalIlluminationState);
+		this.lastKnownGIState = this.lastKnownState.wpc.generalIlluminationState;
+		return result;
+	}
+
+	// NOT IMPLEMENTED YET - needed for alphanumeric games
+	public ChangedLEDs(): number[][] {
+		return [];
+	}
+
+	private getArrayDiff(lastState: Uint8Array, newState: Uint8Array): number[][] {
+		return [];
 	}
 }

--- a/lib/scripting/objects/pinball-backend/emulator-state.ts
+++ b/lib/scripting/objects/pinball-backend/emulator-state.ts
@@ -67,22 +67,22 @@ export class EmulatorState {
 
 	public getSwitchState(index: number): number {
 		const matrixIndex: number = mapIndexToMatrixIndex(index);
-		return this.switchState[matrixIndex];
+		return this.switchState[matrixIndex] || 0;
 	}
 
 	public getLampState(index: number): number {
 		const matrixIndex: number = mapIndexToMatrixIndex(index);
-		return this.currentLampState[matrixIndex];
+		return this.currentLampState[matrixIndex] || 0;
 	}
 
 	public getSolenoidState(index: number): number {
 		const matrixIndex: number = index++;
-		return this.currentSolenoidState[matrixIndex];
+		return this.currentSolenoidState[matrixIndex] || 0;
 	}
 
 	public getGIState(index: number): number {
 		const matrixIndex: number = index++;
-		return this.currentGIState[matrixIndex];
+		return this.currentGIState[matrixIndex] || 0;
 	}
 
 	/**

--- a/lib/scripting/objects/pinball-backend/emulator-state.ts
+++ b/lib/scripting/objects/pinball-backend/emulator-state.ts
@@ -29,6 +29,7 @@ export class EmulatorState {
 	private lastSentSolenoidState: Uint8Array;
 	private lastSentGIState: Uint8Array;
 	private dmdScreen: Uint8Array;
+	private switchState: Uint8Array;
 
 	constructor() {
 		this.lastSentLampState = new Uint8Array();
@@ -38,6 +39,7 @@ export class EmulatorState {
 		this.currentSolenoidState = new Uint8Array();
 		this.currentGIState = new Uint8Array();
 		this.dmdScreen = new Uint8Array();
+		this.switchState = new Uint8Array();
 	}
 
 	public updateState(state: WpcEmuWebWorkerApi.EmuStateAsic) {
@@ -55,6 +57,13 @@ export class EmulatorState {
 		if (state.dmd.dmdShadedBuffer) {
 			this.dmdScreen = state.dmd.dmdShadedBuffer;
 		}
+		if (state.wpc.inputSwitchMatrixActiveColumn) {
+			this.switchState = state.wpc.inputSwitchMatrixActiveColumn;
+		}
+	}
+
+	public getSwitchState(index: number): number {
+		return this.switchState[index];
 	}
 
 	/**

--- a/lib/scripting/objects/pinball-backend/emulator-state.ts
+++ b/lib/scripting/objects/pinball-backend/emulator-state.ts
@@ -20,6 +20,9 @@
 import { WpcEmuWebWorkerApi } from 'wpc-emu';
 import { logger } from '../../../util/logger';
 
+/**
+ * This class encapsulates the WPC-EMU state and transform state object
+ */
 export class EmulatorState {
 
 	private currentLampState: Uint8Array;

--- a/lib/scripting/objects/pinball-backend/emulator-state.ts
+++ b/lib/scripting/objects/pinball-backend/emulator-state.ts
@@ -38,7 +38,7 @@ export class EmulatorState {
 		this.currentGIState = new Uint8Array();
 	}
 
-	public updateState(state: WpcEmuWebWorkerApi.EmuState) {
+	public updateState(state: WpcEmuWebWorkerApi.EmuStateAsic) {
 		if (state.wpc.lampState) {
 			this.currentLampState = this.normalize(state.wpc.lampState);
 		}

--- a/lib/scripting/objects/pinball-backend/emulator-state.ts
+++ b/lib/scripting/objects/pinball-backend/emulator-state.ts
@@ -1,0 +1,38 @@
+/*
+ * VPDB - Virtual Pinball Database
+ * Copyright (C) 2019 freezy <freezy@vpdb.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { logger } from '../../../util/logger';
+import { WpcEmuWebWorkerApi } from 'wpc-emu';
+
+export class EmulatorState {
+
+	private lastKnownState?: WpcEmuWebWorkerApi.EmuState;
+
+	constructor() {
+		this.lastKnownState = undefined;
+	}
+
+	updateState(state: WpcEmuWebWorkerApi.EmuState) {
+		this.lastKnownState = state;
+	}
+
+	getChangedLamps(): void {
+		//TODO
+	}
+}

--- a/lib/scripting/objects/pinball-backend/emulator-state.ts
+++ b/lib/scripting/objects/pinball-backend/emulator-state.ts
@@ -70,6 +70,21 @@ export class EmulatorState {
 		return this.switchState[matrixIndex];
 	}
 
+	public getLampState(index: number): number {
+		const matrixIndex: number = mapIndexToMatrixIndex(index);
+		return this.currentLampState[matrixIndex];
+	}
+
+	public getSolenoidState(index: number): number {
+		const matrixIndex: number = index++;
+		return this.currentSolenoidState[matrixIndex];
+	}
+
+	public getGIState(index: number): number {
+		const matrixIndex: number = index++;
+		return this.currentGIState[matrixIndex];
+	}
+
 	/**
 	 * return changed lamps, index starts at 11..18, 21..28.. up to index 88
 	 */

--- a/lib/scripting/objects/pinball-backend/emulator-state.ts
+++ b/lib/scripting/objects/pinball-backend/emulator-state.ts
@@ -20,6 +20,9 @@
 import { WpcEmuWebWorkerApi } from 'wpc-emu';
 import { logger } from '../../../util/logger';
 
+function getEmptyUint8Array(size: number = 64) {
+	return new Uint8Array(size).fill(0);
+}
 /**
  * This class encapsulates the WPC-EMU state and transform state object
  */
@@ -35,12 +38,12 @@ export class EmulatorState {
 	private switchState: Uint8Array;
 
 	constructor() {
-		this.lastSentLampState = new Uint8Array();
-		this.lastSentSolenoidState = new Uint8Array();
-		this.lastSentGIState = new Uint8Array();
-		this.currentLampState = new Uint8Array();
-		this.currentSolenoidState = new Uint8Array();
-		this.currentGIState = new Uint8Array();
+		this.lastSentLampState = getEmptyUint8Array()
+		this.lastSentSolenoidState = getEmptyUint8Array();
+		this.lastSentGIState = getEmptyUint8Array();
+		this.currentLampState = getEmptyUint8Array();
+		this.currentSolenoidState = getEmptyUint8Array();
+		this.currentGIState = getEmptyUint8Array();
 		this.dmdScreen = new Uint8Array();
 		this.switchState = new Uint8Array();
 	}
@@ -135,8 +138,7 @@ export class EmulatorState {
 			return result;
 		}
 		for (let n: number = 0; n < newState.length; n++) {
-			// HACK: looks like we need the number of lamps per table (here 61)
-			if (n < 62 && lastState[n] !== newState[n]) {
+			if (lastState[n] !== newState[n]) {
 				const index = offsetMapperFunction(n);
 				result.push([index, newState[n]]);
 			}

--- a/lib/scripting/objects/pinball-backend/emulator-state.ts
+++ b/lib/scripting/objects/pinball-backend/emulator-state.ts
@@ -38,7 +38,7 @@ export class EmulatorState {
 	private switchState: Uint8Array;
 
 	constructor() {
-		this.lastSentLampState = getEmptyUint8Array()
+		this.lastSentLampState = getEmptyUint8Array();
 		this.lastSentSolenoidState = getEmptyUint8Array();
 		this.lastSentGIState = getEmptyUint8Array();
 		this.currentLampState = getEmptyUint8Array();

--- a/lib/scripting/objects/pinball-backend/rom-fetcher.spec.ts
+++ b/lib/scripting/objects/pinball-backend/rom-fetcher.spec.ts
@@ -95,7 +95,7 @@ describe('The ROM Fetcher', () => {
 
 		return downloadGameEntry('mm_109c')
 			.catch((error) => {
-				expect(error.message).match(/HTTP error/);
+				expect(error.message).match(/VPDB_FETCH_FAILED_WITH_ERROR_404/);
 				expect(nockScopeA.isDone()).to.equal(true);
 			});
 	});
@@ -111,7 +111,7 @@ describe('The ROM Fetcher', () => {
 
 		return downloadGameEntry('mm_109c')
 			.catch((error) => {
-				expect(error.message).match(/HTTP error/);
+				expect(error.message).match(/VPDB_FETCH_FAILED_WITH_ERROR_404/);
 				expect(nockScopeA.isDone()).to.equal(true);
 			});
 	});

--- a/lib/scripting/objects/pinball-backend/rom-fetcher.spec.ts
+++ b/lib/scripting/objects/pinball-backend/rom-fetcher.spec.ts
@@ -1,0 +1,119 @@
+/*
+ * VPDB - Virtual Pinball Database
+ * Copyright (C) 2019 freezy <freezy@vpdb.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import * as chai from 'chai';
+import { expect } from 'chai';
+import { downloadGameEntry, LoadedGameEntry } from './rom-fetcher';
+import nock = require('nock');
+const fetch = require('node-fetch');
+
+// Yes hacky way to pollute the global scope!
+const globalAny: any = global;
+
+/* tslint:disable:no-unused-expression no-string-literal */
+chai.use(require('sinon-chai'));
+describe('The ROM Fetcher', () => {
+
+	const MOCK_ROM = 'MOCKROM';
+	const VPDB_GAME_ENTRY_JSON = JSON.parse(`[{"id":"mm_109c","version":"v1.09C","notes":"Profanity ROM","languages":[],"rom_files":[{"filename":"mm_1_09c.bin","bytes":1048576,"crc":3655669919,"modified_at":"1996-12-25T04:32:00.000Z","type":"main","system":"wpc"},{"filename":"mm_s2.1_0","bytes":524288,"crc":3311156081,"modified_at":"1996-12-25T04:32:00.000Z","type":"sound"},{"filename":"mm_sav3.rom","bytes":1048576,"crc":3978028400,"modified_at":"1996-12-25T04:32:00.000Z","type":"sound"},{"filename":"mm_sav4.rom","bytes":1048576,"crc":2626284239,"modified_at":"1996-12-25T04:32:00.000Z","type":"sound"},{"filename":"mm_sav5.rom","bytes":1048576,"crc":1158192688,"modified_at":"1996-12-25T04:32:00.000Z","type":"sound"},{"filename":"mm_sav6.rom","bytes":1048576,"crc":1134384626,"modified_at":"1996-12-25T04:32:00.000Z","type":"sound"}],"file":{"id":"p2b9gpvd1","name":"mm_109c.zip","bytes":4933820,"mime_type":"application/zip","url":"https://storage.vpdb.io/files/p2b9gpvd1.zip","is_protected":true,"counter":{"downloads":551},"variations":{}},"created_by":{"id":"p2wrqyf1","name":"uploader","username":"uploader","gravatar_id":"eda3f36c4d9133b05b5f6336a75fcb34"}},{"id":"mm_109b","version":"v1.09B","languages":[],"rom_files":[{"filename":"mm_sav6.rom","bytes":1048576,"crc":1134384626,"modified_at":"2000-07-18T13:40:00.000Z","type":"sound"},{"filename":"mm_sav5.rom","bytes":1048576,"crc":1158192688,"modified_at":"2000-07-18T13:39:46.000Z","type":"sound"},{"filename":"mm_sav4.rom","bytes":1048576,"crc":2626284239,"modified_at":"2000-07-18T13:39:34.000Z","type":"sound"},{"filename":"mm_sav3.rom","bytes":1048576,"crc":3978028400,"modified_at":"2000-07-18T13:39:20.000Z","type":"sound"},{"filename":"mm_s2.1_0","bytes":524288,"crc":3311156081,"modified_at":"1997-07-18T02:52:40.000Z","type":"sound"},{"filename":"mm_109b.bin","bytes":1048576,"crc":1319811178,"modified_at":"1999-06-11T15:22:00.000Z","type":"main","system":"wpc"}],"file":{"id":"pkbkgevd1","name":"mm_109b.zip","bytes":4933798,"mime_type":"application/zip","url":"https://storage.vpdb.io/files/pkbkgevd1.zip","is_protected":true,"counter":{"downloads":381},"variations":{}},"created_by":{"id":"p2wrqyf1","name":"uploader","username":"uploader","gravatar_id":"eda3f36c4d9133b05b5f6336a75fcb34"}},{"id":"mm_109","version":"v1.09","languages":[],"rom_files":[{"filename":"mm_1_09.bin","bytes":1048576,"crc":2611760396,"modified_at":"1996-12-25T04:32:00.000Z","type":"main","system":"wpc"},{"filename":"mm_s2.1_0","bytes":524288,"crc":3311156081,"modified_at":"1996-12-25T04:32:00.000Z","type":"sound"},{"filename":"mm_sav3.rom","bytes":1048576,"crc":3978028400,"modified_at":"1996-12-25T04:32:00.000Z","type":"sound"},{"filename":"mm_sav4.rom","bytes":1048576,"crc":2626284239,"modified_at":"1996-12-25T04:32:00.000Z","type":"sound"},{"filename":"mm_sav5.rom","bytes":1048576,"crc":1158192688,"modified_at":"1996-12-25T04:32:00.000Z","type":"sound"},{"filename":"mm_sav6.rom","bytes":1048576,"crc":1134384626,"modified_at":"1996-12-25T04:32:00.000Z","type":"sound"}],"file":{"id":"e2b3net3o","name":"mm_109.zip","bytes":4933817,"mime_type":"application/zip","url":"https://storage.vpdb.io/files/e2b3net3o.zip","is_protected":true,"counter":{"downloads":339},"variations":{}},"created_by":{"id":"p2wrqyf1","name":"uploader","username":"uploader","gravatar_id":"eda3f36c4d9133b05b5f6336a75fcb34"}},{"id":"mm_10","version":"v1.0","languages":[],"rom_files":[{"filename":"mm_g11.1_0","bytes":524288,"crc":1809266118,"modified_at":"1996-12-25T04:32:00.000Z","type":"main","system":"wpc"},{"filename":"mm_s2.1_0","bytes":524288,"crc":3311156081,"modified_at":"1996-12-25T04:32:00.000Z","type":"sound"},{"filename":"mm_sav3.rom","bytes":1048576,"crc":3978028400,"modified_at":"1996-12-25T04:32:00.000Z","type":"sound"},{"filename":"mm_sav4.rom","bytes":1048576,"crc":2626284239,"modified_at":"1996-12-25T04:32:00.000Z","type":"sound"},{"filename":"mm_sav5.rom","bytes":1048576,"crc":1158192688,"modified_at":"1996-12-25T04:32:00.000Z","type":"sound"},{"filename":"mm_sav6.rom","bytes":1048576,"crc":1134384626,"modified_at":"1996-12-25T04:32:00.000Z","type":"sound"}],"file":{"id":"p2bnnptd1","name":"mm_10.zip","bytes":4929011,"mime_type":"application/zip","url":"https://storage.vpdb.io/files/p2bnnptd1.zip","is_protected":true,"counter":{"downloads":313},"variations":{}},"created_by":{"id":"p2wrqyf1","name":"uploader","username":"uploader","gravatar_id":"eda3f36c4d9133b05b5f6336a75fcb34"}},{"id":"mm_10u","version":"v1.0","notes":"Ultrapin","languages":[],"rom_files":[{"filename":"mmu_g11.1_0","bytes":524288,"crc":643719570,"modified_at":"2006-11-29T16:09:58.000Z","type":"main","system":"wpc"},{"filename":"mm_s2.1_0","bytes":524288,"crc":3311156081,"modified_at":"2001-08-05T11:56:50.000Z","type":"sound"},{"filename":"mm_sav3.rom","bytes":1048576,"crc":3978028400,"modified_at":"2000-07-18T13:39:20.000Z","type":"sound"},{"filename":"mm_sav4.rom","bytes":1048576,"crc":2626284239,"modified_at":"2000-07-18T13:39:34.000Z","type":"sound"},{"filename":"mm_sav5.rom","bytes":1048576,"crc":1158192688,"modified_at":"2000-07-18T13:39:46.000Z","type":"sound"},{"filename":"mm_sav6.rom","bytes":1048576,"crc":1134384626,"modified_at":"2000-07-18T13:40:00.000Z","type":"sound"}],"file":{"id":"e2hp6et3o","name":"mm_10u.zip","bytes":4922916,"mime_type":"application/zip","url":"https://storage.vpdb.io/files/e2hp6et3o.zip","is_protected":true,"counter":{"downloads":296},"variations":{}},"created_by":{"id":"p2wrqyf1","name":"uploader","username":"uploader","gravatar_id":"eda3f36c4d9133b05b5f6336a75fcb34"}},{"id":"mm_05","version":"v0.50","languages":[],"rom_files":[{"filename":"g11-050.rom","bytes":524288,"crc":3524373782,"modified_at":"1996-12-25T04:32:00.000Z","type":"main","system":"wpc"},{"filename":"mm_sav3.rom","bytes":1048576,"crc":3978028400,"modified_at":"1996-12-25T04:32:00.000Z","type":"sound"},{"filename":"mm_sav4.rom","bytes":1048576,"crc":2626284239,"modified_at":"1996-12-25T04:32:00.000Z","type":"sound"},{"filename":"mm_sav5.rom","bytes":1048576,"crc":1158192688,"modified_at":"1996-12-25T04:32:00.000Z","type":"sound"},{"filename":"mm_sav6.rom","bytes":1048576,"crc":1134384626,"modified_at":"1996-12-25T04:32:00.000Z","type":"sound"},{"filename":"s2-020.rom","bytes":524288,"crc":3993017572,"modified_at":"1996-12-25T04:32:00.000Z","type":"sound"}],"file":{"id":"p2buapv31","name":"mm_05.zip","bytes":4855347,"mime_type":"application/zip","url":"https://storage.vpdb.io/files/p2buapv31.zip","is_protected":true,"counter":{"downloads":293},"variations":{}},"created_by":{"id":"p2wrqyf1","name":"uploader","username":"uploader","gravatar_id":"eda3f36c4d9133b05b5f6336a75fcb34"}}]`);
+
+	before(() => {
+		globalAny.fetch = fetch;
+	});
+
+	after(() => {
+		globalAny.fetch = undefined;
+	});
+
+	it('should not find a rom entry', () => {
+		return downloadGameEntry('XXX')
+			.catch((error) => {
+				expect(error.message).match(/GAME_ENTRY_NOT_FOUND_XXX/);
+			});
+	});
+
+	it('should successful download ROM', () => {
+		const nockScopeA = nock('https://api.vpdb.io')
+			.get('/v1/games/mm/roms/')
+			.reply(200, VPDB_GAME_ENTRY_JSON);
+
+		const nockScopeB= nock('https://storage.vpdb.io')
+			.get('/files/p2b9gpvd1.zip/mm_1_09c.bin')
+			.reply(200, MOCK_ROM);
+
+		return downloadGameEntry('mm_109c')
+			.then((answer: LoadedGameEntry) => {
+				expect(answer.romFile).to.deep.equal(new Uint8Array([ 77, 79, 67, 75, 82, 79, 77 ]));
+				expect(answer.wpcDbEntry.name).to.equal('WPC-95: Medieval Madness');
+				expect(nockScopeA.isDone()).to.equal(true);
+				expect(nockScopeB.isDone()).to.equal(true);
+			});
+	});
+
+	it('should handle invalid rom list, option 1', () => {
+		const nockScopeA = nock('https://api.vpdb.io')
+			.get('/v1/games/mm/roms/')
+			.reply(200, { foo: 'bar' });
+
+		return downloadGameEntry('mm_109c')
+			.catch((error) => {
+				expect(error.message).match(/VPDB_INVALID_ANSWER/);
+			});
+	});
+
+	it('should handle invalid rom list, option 2', () => {
+		const nockScopeA = nock('https://api.vpdb.io')
+			.get('/v1/games/mm/roms/')
+			.reply(200, [{ foo: 'bar' }]);
+
+		return downloadGameEntry('mm_109c')
+			.catch((error) => {
+				expect(error.message).match(/VPDB_GAME_ENTRY_NOT_FOUND/);
+			});
+	});
+
+	it('should fail to download Gameset', () => {
+		const nockScopeA = nock('https://api.vpdb.io')
+			.get('/v1/games/mm/roms/')
+			.reply(404);
+
+		return downloadGameEntry('mm_109c')
+			.catch((error) => {
+				expect(error.message).match(/HTTP error/);
+				expect(nockScopeA.isDone()).to.equal(true);
+			});
+	});
+
+	it('should fail to download ROM', () => {
+		const nockScopeA = nock('https://api.vpdb.io')
+			.get('/v1/games/mm/roms/')
+			.reply(200, VPDB_GAME_ENTRY_JSON);
+
+		const nockScopeB= nock('https://storage.vpdb.io')
+			.get('/files/p2b9gpvd1.zip/mm_1_09c.bin')
+			.reply(404);
+
+		return downloadGameEntry('mm_109c')
+			.catch((error) => {
+				expect(error.message).match(/HTTP error/);
+				expect(nockScopeA.isDone()).to.equal(true);
+			});
+	});
+
+});

--- a/lib/scripting/objects/pinball-backend/rom-fetcher.ts
+++ b/lib/scripting/objects/pinball-backend/rom-fetcher.ts
@@ -23,7 +23,7 @@ export function getGameEntry(pinmameGameName: string): Promise<LoadedGameEntry> 
 			return {
 				wpcDbEntry: gameEntry,
 				romFile,
-			}
+			};
 		});
 }
 

--- a/lib/scripting/objects/pinball-backend/rom-fetcher.ts
+++ b/lib/scripting/objects/pinball-backend/rom-fetcher.ts
@@ -13,7 +13,7 @@ export function getGameEntry(pinmameGameName: string): Promise<LoadedGameEntry> 
 			if (!result) {
 				return Promise.reject(new Error('GAME_ENTRY_NOT_FOUND'));
 			}
-			logger().debug(pinmameGameName, 'VPDB RESULT:', result);
+			logger().debug(pinmameGameName, 'VPDB RESULT:', jsonData);
 			// TODO get main ROM from VPDB response
 			const romUrl: string = 'https://storage.vpdb.io/files/p2b9gpvd1.zip/mm_1_09c.bin';
 			logger().debug('load rom from', romUrl);

--- a/lib/scripting/objects/pinball-backend/rom-fetcher.ts
+++ b/lib/scripting/objects/pinball-backend/rom-fetcher.ts
@@ -1,6 +1,10 @@
 import { GamelistDB } from 'wpc-emu';
 import { logger } from '../../../util/logger';
 
+/**
+ * Functions to fetch a WPC ROM file from VPDB.io
+ */
+
 export function getGameEntry(pinmameGameName: string): Promise<LoadedGameEntry> {
 	const gameEntry: undefined | GamelistDB.ClientGameEntry = GamelistDB.getByPinmameName(pinmameGameName);
 	if (!gameEntry) {

--- a/lib/scripting/objects/pinball-backend/rom-fetcher.ts
+++ b/lib/scripting/objects/pinball-backend/rom-fetcher.ts
@@ -1,32 +1,59 @@
 import { GamelistDB } from 'wpc-emu';
 import { logger } from '../../../util/logger';
 
-export function getGameEntry(pinmameGameName: string): Promise<void | Response> {
-	const entry: undefined | GamelistDB.ClientGameEntry = GamelistDB.getByPinmameName(pinmameGameName);
-	if (!entry) {
+export function getGameEntry(pinmameGameName: string): Promise<LoadedGameEntry> {
+	const gameEntry: undefined | GamelistDB.ClientGameEntry = GamelistDB.getByPinmameName(pinmameGameName);
+	if (!gameEntry) {
 		return Promise.reject(new Error('GAME_ENTRY_NOT_FOUND_' + pinmameGameName));
 	}
-	const url: string = buildVpdbUrl(entry.pinmame.vpdbId || entry.pinmame.id);
+	const url: string = buildVpdbGameEntryUrl(gameEntry.pinmame.vpdbId || gameEntry.pinmame.id);
 	return downloadFileAsJson(url)
-		.then((jsonData) => {
-			logger().debug(pinmameGameName, 'FETCHED', jsonData);
-			const result = jsonData.find((vpdbEntry: VpdbGameEntry) => vpdbEntry.id === pinmameGameName);
-			logger().debug('FETCHED', result.file);
-			//TODO get result.file.url
+		.then((jsonData: VpdbGameEntry[]) => {
+			const result: VpdbGameEntry | void = jsonData.find((vpdbEntry: VpdbGameEntry) => vpdbEntry.id === pinmameGameName);
+			if (!result) {
+				return Promise.reject(new Error('GAME_ENTRY_NOT_FOUND'));
+			}
+			logger().debug(pinmameGameName, 'VPDB RESULT:', result);
+			// TODO get main ROM from VPDB response
+			const romUrl: string = 'https://storage.vpdb.io/files/p2b9gpvd1.zip/mm_1_09c.bin';
+			logger().debug('load rom from', romUrl);
+			return downloadFileAsUint8Array(romUrl);
+		})
+		.then((romFile: Uint8Array) => {
+			return {
+				wpcDbEntry: gameEntry,
+				romFile,
+			}
 		});
 }
 
-function buildVpdbUrl(id: string): string {
+function buildVpdbGameEntryUrl(id: string): string {
 	return `https://api.vpdb.io/v1/games/${id}/roms/`;
 }
 
-function downloadFileAsJson(url: string): Promise<void | Response> {
+function downloadFileAsJson(url: string): Promise<VpdbGameEntry[]> {
 	return fetch(url).then((response) => {
 		if (!response.ok) {
 			return Promise.reject(new Error('HTTP error, status = ' + response.status));
 		}
 		return response.json();
 	});
+}
+
+function downloadFileAsUint8Array(url: string): Promise<Uint8Array> {
+	return fetch(url).then((response) => {
+		if (!response.ok) {
+			return Promise.reject(new Error('HTTP error, status = ' + response.status));
+		}
+		return response.arrayBuffer();
+	}).then((arrayBuffer) => {
+		return new Uint8Array(arrayBuffer);
+	});
+}
+
+export interface LoadedGameEntry {
+	wpcDbEntry: GamelistDB.ClientGameEntry;
+	romFile: Uint8Array;
 }
 
 interface VpdbGameEntry {

--- a/lib/scripting/objects/pinball-backend/rom-fetcher.ts
+++ b/lib/scripting/objects/pinball-backend/rom-fetcher.ts
@@ -6,7 +6,7 @@ import { logger } from '../../../util/logger';
  */
 
 export function downloadGameEntry(pinmameGameName: string): Promise<LoadedGameEntry> {
-	const gameEntry: undefined | GamelistDB.ClientGameEntry = GamelistDB.getByPinmameName(pinmameGameName);
+	const gameEntry = GamelistDB.getByPinmameName(pinmameGameName);
 	if (!gameEntry) {
 		return Promise.reject(new Error('GAME_ENTRY_NOT_FOUND_' + pinmameGameName));
 	}
@@ -16,25 +16,25 @@ export function downloadGameEntry(pinmameGameName: string): Promise<LoadedGameEn
 			if (!Array.isArray(jsonData)) {
 				return Promise.reject(new Error('VPDB_INVALID_ANSWER'));
 			}
-			const result: VpdbGameEntry | void = jsonData.find((vpdbEntry: VpdbGameEntry) => vpdbEntry.id === pinmameGameName);
+			const result = jsonData.find((vpdbEntry: VpdbGameEntry) => vpdbEntry.id === pinmameGameName);
 			if (!result) {
 				return Promise.reject(new Error('VPDB_GAME_ENTRY_NOT_FOUND'));
 			}
 			logger().debug(pinmameGameName, 'VPDB RESULT:', jsonData);
 
-			const romSet: VpdbGameEntry | void = findRomSet(jsonData, pinmameGameName);
+			const romSet = findRomSet(jsonData, pinmameGameName);
 			if (!romSet) {
 				return Promise.reject(new Error('VPDB_ROMSET_ENTRY_NOT_FOUND'));
 			}
 			logger().debug(pinmameGameName, 'VPDB romSet:', romSet);
 
-			const romName: string | undefined = findMainRomFilename(romSet);
+			const romName = findMainRomFilename(romSet);
 			if (!romName) {
 				return Promise.reject(new Error('VPDB_ROM_TYPE_NOT_FOUND'));
 			}
 			logger().debug(pinmameGameName, 'VPDB romName:', romName);
 
-			const romUrl: string = buildVpdbGameRomUrl(romSet.file.url, romName);
+			const romUrl = buildVpdbGameRomUrl(romSet.file.url, romName);
 			logger().debug('load rom from', romUrl, ', # downloads', romSet.file.counter.downloads);
 			return downloadFileAsUint8Array(romUrl);
 		})
@@ -46,7 +46,7 @@ export function downloadGameEntry(pinmameGameName: string): Promise<LoadedGameEn
 		});
 }
 
-function findMainRomFilename(romSet: VpdbGameEntry): string | undefined {
+function findMainRomFilename(romSet: VpdbGameEntry): string {
 	const vpdbGameRomEntry: VpdbGameRomEntry | undefined = romSet.rom_files.find((entry: VpdbGameRomEntry) => entry.type === 'main');
 	if (!vpdbGameRomEntry) {
 		return '';

--- a/lib/scripting/objects/pinball-backend/wpc-emu.spec.ts
+++ b/lib/scripting/objects/pinball-backend/wpc-emu.spec.ts
@@ -48,6 +48,10 @@ describe('WPC-EMU', () => {
 		expect(result.length).to.equal(0);
 	});
 
+	it('should ignore registerAudioConsumer when emu is not initialized', () => {
+		emulator.registerAudioConsumer((id) => {});
+	});
+
 	it('getDmdDimensions should return correct size', () => {
 		const result: Vertex2D = emulator.getDmdDimensions();
 		expect(result.x).to.equal(128);

--- a/lib/scripting/objects/pinball-backend/wpc-emu.spec.ts
+++ b/lib/scripting/objects/pinball-backend/wpc-emu.spec.ts
@@ -1,0 +1,56 @@
+/*
+ * VPDB - Virtual Pinball Database
+ * Copyright (C) 2019 freezy <freezy@vpdb.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import * as chai from 'chai';
+import { expect } from 'chai';
+import { Emulator } from './wpc-emu';
+import { Vertex2D } from '../../../math/vertex2d';
+
+/* tslint:disable:no-unused-expression no-string-literal */
+chai.use(require('sinon-chai'));
+describe('WPC-EMU', () => {
+
+	let emulator: Emulator;
+
+	beforeEach(() => {
+		emulator = new Emulator();
+	});
+
+	it.skip('getVersion should be defined', () => {
+		const result: string = emulator.getVersion();
+		expect(result.length > 4).to.equal(true);
+	});
+
+	it('getDmdDimensions should return correct size', () => {
+		const result: Vertex2D = emulator.getDmdDimensions();
+		expect(result.x).to.equal(128);
+		expect(result.y).to.equal(32);
+	});
+
+	it('should ignore calls as long as the emu is not initialized', () => {
+		emulator.setSwitchInput(4);
+		emulator.setSwitchInput(4, true);
+		emulator.setSwitchInput(4, false);
+		emulator.setCabinetInput(4);
+		emulator.setFliptronicsInput('FOO');
+		const executedSteps = emulator.emuSimulateCycle(200);
+		expect(executedSteps).to.equal(0);
+	});
+
+});

--- a/lib/scripting/objects/pinball-backend/wpc-emu.spec.ts
+++ b/lib/scripting/objects/pinball-backend/wpc-emu.spec.ts
@@ -32,9 +32,20 @@ describe('WPC-EMU', () => {
 		emulator = new Emulator();
 	});
 
+	//TODO this fails due wpc-emu module loader
 	it.skip('getVersion should be defined', () => {
 		const result: string = emulator.getVersion();
 		expect(result.length > 4).to.equal(true);
+	});
+
+	it('should not be initialized by default', () => {
+		const result: boolean = emulator.isInitialized();
+		expect(result).to.equal(false);
+	});
+
+	it('should get getDmdFrame', () => {
+		const result: Uint8Array = emulator.getDmdFrame();
+		expect(result.length).to.equal(0);
 	});
 
 	it('getDmdDimensions should return correct size', () => {

--- a/lib/scripting/objects/pinball-backend/wpc-emu.ts
+++ b/lib/scripting/objects/pinball-backend/wpc-emu.ts
@@ -20,15 +20,18 @@
 import { GamelistDB, WpcEmuApi, WpcEmuWebWorkerApi } from 'wpc-emu';
 import { logger } from '../../../util/logger';
 import { IEmulator } from '../../../game/iemulator';
+import { EmulatorState } from './emulator-state';
 
 export class Emulator implements IEmulator {
 	private emulator?: WpcEmuApi.Emulator;
+	public readonly emulatorState: EmulatorState;
 	private romLoading: boolean;
 
 	constructor() {
 		logger().debug('HELLO FROM WPC CONTROLLER');
 		this.emulator = undefined;
 		this.romLoading = false;
+		this.emulatorState = new EmulatorState();
 	}
 
 	public loadGame(gameEntry: GamelistDB.GameEntry, romContent: Uint8Array) {
@@ -62,7 +65,9 @@ export class Emulator implements IEmulator {
 		if (!this.emulator) {
 			return 0;
 		}
-		return this.emulator.executeCycleForTime(advanceByMs, 16);
+		const executedCycles: number = this.emulator.executeCycleForTime(advanceByMs, 16);
+		this.emulatorState.updateState(this.emulator.getUiState());
+		return executedCycles;
 	}
 
 	public setInput(switchNr: number): void {

--- a/lib/scripting/objects/pinball-backend/wpc-emu.ts
+++ b/lib/scripting/objects/pinball-backend/wpc-emu.ts
@@ -101,19 +101,48 @@ export class Emulator implements IEmulator {
 		return executedCycles;
 	}
 
-	public getInput(switchNr: number): number {
+	public getSwitchInput(switchNr: number): number {
 		if (!this.emulator) {
 			return 0;
 		}
 		return this.emulatorState.getSwitchState(switchNr);
 	}
 
-	public setInput(switchNr: number): void {
+	public getLampState(lampNr: number): number {
 		if (!this.emulator) {
-			this.emulatorCachingService.cacheState(CacheType.SetSwitchInput, switchNr);
-			return;
+			return 0;
 		}
+		return this.emulatorState.getLampState(lampNr);
+	}
+
+	public getSolenoidState(SolenoidNr: number): number {
+		if (!this.emulator) {
+			return 0;
+		}
+		return this.emulatorState.getSolenoidState(SolenoidNr);
+	}
+
+	public getGIState(giNr: number): number {
+		if (!this.emulator) {
+			return 0;
+		}
+		return this.emulatorState.getGIState(giNr);
+	}
+
+	/**
+	 * Update Switch State
+	 * @param switchNr which switch number (11..88) to modifiy
+	 * @param optionalEnableSwitch if this parameter is missing, the switch will be toggled, else set to the defined state
+	 */
+	public setSwitchInput(switchNr: number, optionalEnableSwitch?: number): boolean {
+		if (!this.emulator) {
+			//TODO add ClearSwitchInput here
+			this.emulatorCachingService.cacheState(CacheType.SetSwitchInput, switchNr);
+			return true;
+		}
+		//TODO pass optionalEnableSwitch
 		this.emulator.setInput(switchNr);
+		return true;
 	}
 
 	public setCabinetInput(value: number): void {

--- a/lib/scripting/objects/pinball-backend/wpc-emu.ts
+++ b/lib/scripting/objects/pinball-backend/wpc-emu.ts
@@ -58,7 +58,7 @@ export class Emulator implements IEmulator {
 				cachedData.forEach((cacheEntry: CacheEntry) => {
 					switch (cacheEntry.cacheType) {
 						case CacheType.SetSwitchInput:
-							return emulator.setInput(cacheEntry.value);
+							return emulator.setSwitchInput(cacheEntry.value);
 						default:
 							logger().warn('UNKNOWN CACHE TYPE', cacheEntry.cacheType);
 					}
@@ -141,7 +141,7 @@ export class Emulator implements IEmulator {
 			return true;
 		}
 		//TODO pass optionalEnableSwitch
-		this.emulator.setInput(switchNr);
+		this.emulator.setSwitchInput(switchNr);
 		return true;
 	}
 

--- a/lib/scripting/objects/pinball-backend/wpc-emu.ts
+++ b/lib/scripting/objects/pinball-backend/wpc-emu.ts
@@ -61,7 +61,6 @@ export class Emulator implements IEmulator {
 	}
 
 	public emuSimulateCycle(advanceByMs: number): number {
-		logger().debug('emuSimulateCycle', advanceByMs);
 		if (!this.emulator) {
 			return 0;
 		}

--- a/lib/scripting/objects/pinball-backend/wpc-emu.ts
+++ b/lib/scripting/objects/pinball-backend/wpc-emu.ts
@@ -55,7 +55,7 @@ export class Emulator implements IEmulator {
 
 				this.emulatorCachingService.applyCache(this);
 
-				//TODO HACK - used to launch the rom
+				//TODO HACK - used to launch the rom - if we have a RAM state, this would be obsolete!
 				setTimeout(() => {
 					logger().info('ESC!');
 					emulator.setCabinetInput(16);
@@ -65,9 +65,6 @@ export class Emulator implements IEmulator {
 	}
 
 	public getVersion(): string {
-		if (!this.emulator) {
-			return 'unknown';
-		}
 		return WpcEmuApi.getVersion();
 	}
 
@@ -94,30 +91,18 @@ export class Emulator implements IEmulator {
 	}
 
 	public getSwitchInput(switchNr: number): number {
-		if (!this.emulator) {
-			return 0;
-		}
 		return this.emulatorState.getSwitchState(switchNr);
 	}
 
 	public getLampState(lampNr: number): number {
-		if (!this.emulator) {
-			return 0;
-		}
 		return this.emulatorState.getLampState(lampNr);
 	}
 
 	public getSolenoidState(SolenoidNr: number): number {
-		if (!this.emulator) {
-			return 0;
-		}
 		return this.emulatorState.getSolenoidState(SolenoidNr);
 	}
 
 	public getGIState(giNr: number): number {
-		if (!this.emulator) {
-			return 0;
-		}
 		return this.emulatorState.getGIState(giNr);
 	}
 
@@ -143,6 +128,7 @@ export class Emulator implements IEmulator {
 
 	public setCabinetInput(value: number): void {
 		if (!this.emulator) {
+			this.emulatorCachingService.cacheState(CacheType.CabinetInput, value);
 			return;
 		}
 		this.emulator.setCabinetInput(value);

--- a/lib/scripting/objects/pinball-backend/wpc-emu.ts
+++ b/lib/scripting/objects/pinball-backend/wpc-emu.ts
@@ -80,6 +80,9 @@ export class Emulator implements IEmulator {
 	}
 
 	public setFliptronicsInput(value: string): void {
+    if (!this.emulator) {
+			return;
+		}
 		this.emulator.setFliptronicsInput(value);
 	}
 

--- a/lib/scripting/objects/pinball-backend/wpc-emu.ts
+++ b/lib/scripting/objects/pinball-backend/wpc-emu.ts
@@ -38,19 +38,18 @@ export class Emulator implements IEmulator {
 		this.emulator = undefined;
 	}
 
-	public loadGame(gameEntry: GamelistDB.GameEntry, romContent: Uint8Array) {
+	public async loadGame(gameEntry: GamelistDB.GameEntry, romContent: Uint8Array) {
 		const romData: GamelistDB.RomData = { u06: romContent };
-		return WpcEmuApi.initVMwithRom(romData, gameEntry)
-			.then((emulator: WpcEmuApi.Emulator) => {
-				this.emulator = emulator;
-				this.emulator.reset();
-				// Let the ROM boot, run for 1000ms
-				this.emulator.executeCycleForTime(1000, 4);
-				// Set initial state for emulator and press ESC to remove the initial
-				// message that the RAM was cleared
-				this.emulatorCachingService.cacheState(CacheType.CabinetInput, 16);
-				this.emulatorCachingService.applyCache(this);
-			});
+		const emulator = await WpcEmuApi.initVMwithRom(romData, gameEntry)
+
+		this.emulator = emulator;
+		this.emulator.reset();
+		// Let the ROM boot, run for 1000ms
+		this.emulator.executeCycleForTime(1000, 4);
+		// Set initial state for emulator and press ESC to remove the initial
+		// message that the RAM was cleared
+		this.emulatorCachingService.cacheState(CacheType.CabinetInput, 16);
+		this.emulatorCachingService.applyCache(this);
 	}
 
 	public isInitialized(): boolean {

--- a/lib/scripting/objects/pinball-backend/wpc-emu.ts
+++ b/lib/scripting/objects/pinball-backend/wpc-emu.ts
@@ -18,8 +18,8 @@
  */
 
 import { GamelistDB, WpcEmuApi, WpcEmuWebWorkerApi } from 'wpc-emu';
-import { logger } from '../../../util/logger';
 import { IEmulator } from '../../../game/iemulator';
+import { logger } from '../../../util/logger';
 import { EmulatorState } from './emulator-state';
 
 export class Emulator implements IEmulator {
@@ -61,7 +61,7 @@ export class Emulator implements IEmulator {
 	}
 
 	public emuSimulateCycle(advanceByMs: number): number {
-		console.log('emuSimulateCycle', advanceByMs);
+		logger().debug('emuSimulateCycle', advanceByMs);
 		if (!this.emulator) {
 			return 0;
 		}
@@ -85,7 +85,7 @@ export class Emulator implements IEmulator {
 	}
 
 	public setFliptronicsInput(value: string): void {
-    if (!this.emulator) {
+		if (!this.emulator) {
 			return;
 		}
 		this.emulator.setFliptronicsInput(value);

--- a/lib/scripting/objects/pinball-backend/wpc-emu.ts
+++ b/lib/scripting/objects/pinball-backend/wpc-emu.ts
@@ -50,7 +50,7 @@ export class Emulator implements IEmulator {
 				//TODO HACK - used to launch the rom
 				setTimeout(() => {
 					console.log('RSET!')
-					this.emulator.reset();
+					emulator.reset();
 				}, 8000);
 
 			});

--- a/lib/scripting/objects/pinball-backend/wpc-emu.ts
+++ b/lib/scripting/objects/pinball-backend/wpc-emu.ts
@@ -51,7 +51,7 @@ export class Emulator implements IEmulator {
 				setTimeout(() => {
 					console.log('RSET!')
 					emulator.reset();
-				}, 8000);
+				}, 2000);
 
 			});
 	}

--- a/lib/scripting/objects/pinball-backend/wpc-emu.ts
+++ b/lib/scripting/objects/pinball-backend/wpc-emu.ts
@@ -36,7 +36,6 @@ export class Emulator implements IEmulator {
 	private readonly dmdSize = new Vertex2D(128, 32);
 
 	constructor() {
-		logger().debug('HELLO FROM WPC CONTROLLER');
 		this.emulator = undefined;
 		this.emulatorState = new EmulatorState();
 		this.emulatorCachingService = new EmulatorCachingService();

--- a/lib/scripting/objects/pinball-backend/wpc-emu.ts
+++ b/lib/scripting/objects/pinball-backend/wpc-emu.ts
@@ -141,14 +141,6 @@ export class Emulator implements IEmulator {
 		this.emulator.setFliptronicsInput(value);
 	}
 
-	// TODO, this emuchecking sucks...
-	public getState(): WpcEmuWebWorkerApi.EmuState | undefined {
-		if (!this.emulator) {
-			return;
-		}
-		return this.emulator.getUiState();
-	}
-
 	public getDmdDimensions(): Vertex2D {
 		return this.dmdSize;
 	}

--- a/lib/scripting/objects/pinball-backend/wpc-emu.ts
+++ b/lib/scripting/objects/pinball-backend/wpc-emu.ts
@@ -22,6 +22,8 @@ import { IEmulator } from '../../../game/iemulator';
 import { logger } from '../../../util/logger';
 import { EmulatorState } from './emulator-state';
 
+const WPC_EMU_INCLUDE_RAM_AND_VIDEORAM_DATA = false;
+
 export class Emulator implements IEmulator {
 	private emulator?: WpcEmuApi.Emulator;
 	public readonly emulatorState: EmulatorState;
@@ -65,7 +67,8 @@ export class Emulator implements IEmulator {
 			return 0;
 		}
 		const executedCycles: number = this.emulator.executeCycleForTime(advanceByMs, 16);
-		this.emulatorState.updateState(this.emulator.getUiState());
+		const emuState: WpcEmuWebWorkerApi.EmuState = this.emulator.getUiState(WPC_EMU_INCLUDE_RAM_AND_VIDEORAM_DATA);
+		this.emulatorState.updateState(emuState.asic);
 		return executedCycles;
 	}
 

--- a/lib/scripting/objects/pinball-backend/wpc-emu.ts
+++ b/lib/scripting/objects/pinball-backend/wpc-emu.ts
@@ -107,8 +107,12 @@ export class Emulator implements IEmulator {
 		return this.dmdSize;
 	}
 
+	/**
+	 * returns the content of the DMD display, 1 byte per pixel
+	 * values range from 0 (dark) to 3 (bright) - this means the Uint8Array needs to be postprocessed
+	 */
 	public getDmdFrame(): Uint8Array {
-		return new Uint8Array();
+		return this.emulatorState.getDmdScreen();
 	}
 
 }

--- a/lib/scripting/objects/pinball-backend/wpc-emu.ts
+++ b/lib/scripting/objects/pinball-backend/wpc-emu.ts
@@ -30,22 +30,14 @@ export class Emulator {
 		this.romLoading = false;
 	}
 
-	public loadGame(gameName: string) {
-		const romData: GamelistDB.RomData = { u06: new Uint8Array(128 * 1024) };
-		const gameEntry: GamelistDB.GameEntry = {
-			name: 'foo',
-			rom: {
-				u06: 'my.rom',
-			},
-			skipWpcRomCheck: false,
-			fileName: 'fooname',
-			features: ['wpc95'],
-		};
+	public loadGame(gameEntry: GamelistDB.GameEntry, romContent: Uint8Array) {
+		const romData: GamelistDB.RomData = { u06: romContent };
 		this.romLoading = true;
 		return WpcEmuApi.initVMwithRom(romData, gameEntry)
 			.then((emulator: WpcEmuApi.Emulator) => {
 				this.emulator = emulator;
 				this.romLoading = false;
+				this.emulator.reset();
 			});
 	}
 

--- a/lib/scripting/objects/pinball-backend/wpc-emu.ts
+++ b/lib/scripting/objects/pinball-backend/wpc-emu.ts
@@ -70,6 +70,7 @@ export class Emulator implements IEmulator {
 		}
 		const executedCycles: number = this.emulator.executeCycleForTime(advanceByMs, 16);
 		const emuState: WpcEmuWebWorkerApi.EmuState = this.emulator.getUiState(WPC_EMU_INCLUDE_RAM_AND_VIDEORAM_DATA);
+		//logger().debug('TICKS', emuState.cpuState.tickCount);
 		this.emulatorState.updateState(emuState.asic);
 		return executedCycles;
 	}

--- a/lib/scripting/objects/pinball-backend/wpc-emu.ts
+++ b/lib/scripting/objects/pinball-backend/wpc-emu.ts
@@ -82,6 +82,13 @@ export class Emulator implements IEmulator {
 		return executedCycles;
 	}
 
+	public getInput(switchNr: number): number {
+		if (!this.emulator) {
+			return 0;
+		}
+		return this.emulatorState.getSwitchState(switchNr);
+	}
+
 	public setInput(switchNr: number): void {
 		if (!this.emulator) {
 			return;

--- a/lib/scripting/objects/pinball-backend/wpc-emu.ts
+++ b/lib/scripting/objects/pinball-backend/wpc-emu.ts
@@ -34,23 +34,19 @@ export class Emulator implements IEmulator {
 	private emulatorCachingService: EmulatorCachingService;
 	public readonly emulatorState: EmulatorState;
 	private readonly dmdSize = new Vertex2D(128, 32);
-	private romLoading: boolean;
 
 	constructor() {
 		logger().debug('HELLO FROM WPC CONTROLLER');
 		this.emulator = undefined;
-		this.romLoading = false;
 		this.emulatorState = new EmulatorState();
 		this.emulatorCachingService = new EmulatorCachingService();
 	}
 
 	public loadGame(gameEntry: GamelistDB.GameEntry, romContent: Uint8Array) {
 		const romData: GamelistDB.RomData = { u06: romContent };
-		this.romLoading = true;
 		return WpcEmuApi.initVMwithRom(romData, gameEntry)
 			.then((emulator: WpcEmuApi.Emulator) => {
 				this.emulator = emulator;
-				this.romLoading = false;
 				this.emulator.reset();
 
 				this.emulatorCachingService.applyCache(this);
@@ -60,8 +56,11 @@ export class Emulator implements IEmulator {
 					logger().info('ESC!');
 					emulator.setCabinetInput(16);
 				}, 2000);
-
 			});
+	}
+
+	public isInitialized(): boolean {
+		return this.emulator !== undefined;
 	}
 
 	public getVersion(): string {

--- a/lib/scripting/objects/pinball-backend/wpc-emu.ts
+++ b/lib/scripting/objects/pinball-backend/wpc-emu.ts
@@ -21,12 +21,14 @@ import { GamelistDB, WpcEmuApi, WpcEmuWebWorkerApi } from 'wpc-emu';
 import { IEmulator } from '../../../game/iemulator';
 import { logger } from '../../../util/logger';
 import { EmulatorState } from './emulator-state';
+import { Vertex2D } from '../../../math/vertex2d';
 
 const WPC_EMU_INCLUDE_RAM_AND_VIDEORAM_DATA = false;
 
 export class Emulator implements IEmulator {
 	private emulator?: WpcEmuApi.Emulator;
 	public readonly emulatorState: EmulatorState;
+	private readonly dmdSize = new Vertex2D(128, 32);
 	private romLoading: boolean;
 
 	constructor() {
@@ -99,6 +101,14 @@ export class Emulator implements IEmulator {
 			return;
 		}
 		return this.emulator.getUiState();
+	}
+
+	public getDmdDimensions(): Vertex2D {
+		return this.dmdSize;
+	}
+
+	public getDmdFrame(): Uint8Array {
+		return new Uint8Array();
 	}
 
 }

--- a/lib/scripting/objects/pinball-backend/wpc-emu.ts
+++ b/lib/scripting/objects/pinball-backend/wpc-emu.ts
@@ -19,8 +19,9 @@
 
 import { GamelistDB, WpcEmuApi } from 'wpc-emu';
 import { logger } from '../../../util/logger';
+import { IEmulator } from '../../../game/iemulator';
 
-export class Emulator {
+export class Emulator implements IEmulator {
 	private emulator?: WpcEmuApi.Emulator;
 	private romLoading: boolean;
 
@@ -56,7 +57,7 @@ export class Emulator {
 		this.emulator.registerAudioConsumer(callbackFunction);
 	}
 
-	public executeCycleForTime(advanceByMs: number): number {
+	public emuSimulateCycle(advanceByMs: number): number {
 		if (!this.emulator) {
 			return 0;
 		}

--- a/lib/scripting/objects/pinball-backend/wpc-emu.ts
+++ b/lib/scripting/objects/pinball-backend/wpc-emu.ts
@@ -17,7 +17,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { GamelistDB, WpcEmuApi } from 'wpc-emu';
+import { GamelistDB, WpcEmuApi, WpcEmuWebWorkerApi } from 'wpc-emu';
 import { logger } from '../../../util/logger';
 import { IEmulator } from '../../../game/iemulator';
 
@@ -58,6 +58,7 @@ export class Emulator implements IEmulator {
 	}
 
 	public emuSimulateCycle(advanceByMs: number): number {
+		console.log('emuSimulateCycle', advanceByMs);
 		if (!this.emulator) {
 			return 0;
 		}
@@ -79,10 +80,15 @@ export class Emulator implements IEmulator {
 	}
 
 	public setFliptronicsInput(value: string): void {
+		this.emulator.setFliptronicsInput(value);
+	}
+
+	// TODO, this emuchecking sucks...
+	public getState(): WpcEmuWebWorkerApi.EmuState | undefined {
 		if (!this.emulator) {
 			return;
 		}
-		this.emulator.setFliptronicsInput(value);
+		return this.emulator.getUiState();
 	}
 
 }

--- a/lib/scripting/objects/pinball-backend/wpc-emu.ts
+++ b/lib/scripting/objects/pinball-backend/wpc-emu.ts
@@ -46,6 +46,13 @@ export class Emulator implements IEmulator {
 				this.emulator = emulator;
 				this.romLoading = false;
 				this.emulator.reset();
+
+				//TODO HACK - used to launch the rom
+				setTimeout(() => {
+					console.log('RSET!')
+					this.emulator.reset();
+				}, 8000);
+
 			});
 	}
 

--- a/lib/scripting/objects/pinball-backend/wpc-emu.ts
+++ b/lib/scripting/objects/pinball-backend/wpc-emu.ts
@@ -20,7 +20,6 @@
 import { GamelistDB, WpcEmuApi, WpcEmuWebWorkerApi } from 'wpc-emu';
 import { IEmulator } from '../../../game/iemulator';
 import { Vertex2D } from '../../../math/vertex2d';
-import { logger } from '../../../util/logger';
 import { CacheType, EmulatorCachingService } from './caching-service';
 import { EmulatorState } from './emulator-state';
 
@@ -30,15 +29,13 @@ const WPC_EMU_INCLUDE_RAM_AND_VIDEORAM_DATA = false;
  * Provides an interface to WPC-EMU
  */
 export class Emulator implements IEmulator {
-	public readonly emulatorState: EmulatorState;
-	private emulator?: WpcEmuApi.Emulator;
-	private emulatorCachingService: EmulatorCachingService;
+	public readonly emulatorState: EmulatorState = new EmulatorState();
+	private emulator?: WpcEmuApi.Emulator = undefined;
+	private readonly emulatorCachingService: EmulatorCachingService = new EmulatorCachingService();
 	private readonly dmdSize = new Vertex2D(128, 32);
 
 	constructor() {
 		this.emulator = undefined;
-		this.emulatorState = new EmulatorState();
-		this.emulatorCachingService = new EmulatorCachingService();
 	}
 
 	public loadGame(gameEntry: GamelistDB.GameEntry, romContent: Uint8Array) {

--- a/lib/scripting/objects/pinball-backend/wpc-emu.ts
+++ b/lib/scripting/objects/pinball-backend/wpc-emu.ts
@@ -30,9 +30,9 @@ const WPC_EMU_INCLUDE_RAM_AND_VIDEORAM_DATA = false;
  * Provides an interface to WPC-EMU
  */
 export class Emulator implements IEmulator {
+	public readonly emulatorState: EmulatorState;
 	private emulator?: WpcEmuApi.Emulator;
 	private emulatorCachingService: EmulatorCachingService;
-	public readonly emulatorState: EmulatorState;
 	private readonly dmdSize = new Vertex2D(128, 32);
 
 	constructor() {

--- a/lib/scripting/objects/pinball-backend/wpc-emu.ts
+++ b/lib/scripting/objects/pinball-backend/wpc-emu.ts
@@ -48,14 +48,12 @@ export class Emulator implements IEmulator {
 			.then((emulator: WpcEmuApi.Emulator) => {
 				this.emulator = emulator;
 				this.emulator.reset();
-
+				// Let the ROM boot, run for 1000ms
+				this.emulator.executeCycleForTime(1000, 4);
+				// Set initial state for emulator and press ESC to remove the initial
+				// message that the RAM was cleared
+				this.emulatorCachingService.cacheState(CacheType.CabinetInput, 16);
 				this.emulatorCachingService.applyCache(this);
-
-				//TODO HACK - used to launch the rom - if we have a RAM state, this would be obsolete!
-				setTimeout(() => {
-					logger().info('ESC!');
-					emulator.setCabinetInput(16);
-				}, 2000);
 			});
 	}
 

--- a/lib/scripting/objects/vpm-controller.spec.ts
+++ b/lib/scripting/objects/vpm-controller.spec.ts
@@ -54,7 +54,7 @@ describe('The VpmController - VISUAL PINMAME COM OBJECT', () => {
 		expect(vpmController.Dip[40]).to.equal(VALUE);
 	});
 
-	it.skip('no changed lamps detected', () => {
+	it('no changed lamps detected', () => {
 		const result = vpmController.ChangedLamps;
 		expect(result).to.deep.equal([]);
 	});
@@ -65,6 +65,11 @@ describe('The VpmController - VISUAL PINMAME COM OBJECT', () => {
 		expect(resultIndex).to.equal(42);
 		//TODO unclear if uint8 or float type
 		expect(resultValue).to.equal(0.5);
+	});
+
+	it.skip('get Switch 0', () => {
+		const result = vpmController.Switch[0];
+		expect(result).to.deep.equal(0);
 	});
 
 

--- a/lib/scripting/objects/vpm-controller.spec.ts
+++ b/lib/scripting/objects/vpm-controller.spec.ts
@@ -26,7 +26,7 @@ import { VpmController } from './vpm-controller';
 
 /* tslint:disable:no-unused-expression no-string-literal */
 chai.use(require('sinon-chai'));
-describe.only('The VpmController - VISUAL PINMAME COM OBJECT', () => {
+describe('The VpmController - VISUAL PINMAME COM OBJECT', () => {
 
 	let vpmController: VpmController;
 

--- a/lib/scripting/objects/vpm-controller.spec.ts
+++ b/lib/scripting/objects/vpm-controller.spec.ts
@@ -94,4 +94,102 @@ describe.only('The VpmController - VISUAL PINMAME COM OBJECT', () => {
 		expect(result).to.deep.equal(0);
 	});
 
+	it('is WPCNumbering?', () => {
+		const result: number = vpmController.WPCNumbering;
+		expect(result).to.equal(1);
+	});
+
+	it('get SampleRate', () => {
+		const result: number = vpmController.SampleRate;
+		expect(result).to.equal(22050);
+	});
+
+	it('set and get SplashInfoLine', () => {
+		vpmController.SplashInfoLine = 'SPLASH!';
+		const result: string = vpmController.SplashInfoLine;
+		expect(result).to.equal('SPLASH!');
+	});
+
+	it('dummy Debugging function (GET): ShowDMDOnly', () => {
+		const result: boolean = vpmController.ShowDMDOnly;
+		expect(result).to.equal(false);
+	});
+
+	it('dummy Debugging function (GET): HandleKeyboard', () => {
+		const result: boolean = vpmController.HandleKeyboard;
+		expect(result).to.equal(false);
+	});
+
+	it('dummy Debugging function (GET): ShowTitle', () => {
+		const result: boolean = vpmController.ShowTitle;
+		expect(result).to.equal(false);
+	});
+
+	it('set dummy Debugging functions', () => {
+		vpmController.ShowDMDOnly = true;
+		vpmController.HandleKeyboard = true;
+		vpmController.ShowTitle = true;
+		expect(vpmController.ShowTitle).to.equal(false);
+	});
+
+	it('dummy Customization function (GET): LockDisplay', () => {
+		vpmController.LockDisplay = true;
+		const result: boolean = vpmController.LockDisplay;
+		expect(result).to.equal(false);
+	});
+
+	it('dummy Customization function: Hidden', () => {
+		vpmController.Hidden = true;
+		const result: boolean = vpmController.Hidden;
+		expect(result).to.equal(false);
+	});
+
+	it('dummy Customization function: DoubleSize', () => {
+		vpmController.DoubleSize = true;
+		const result: boolean = vpmController.DoubleSize;
+		expect(result).to.equal(false);
+	});
+
+	it('dummy Customization function: Antialias', () => {
+		vpmController.Antialias = true;
+		const result: boolean = vpmController.Antialias;
+		expect(result).to.equal(false);
+	});
+
+	it('dummy Customization function: ShowFrame', () => {
+		vpmController.ShowFrame = true;
+		const result: boolean = vpmController.ShowFrame;
+		expect(result).to.equal(false);
+	});
+
+	it('dummy Customization function: DoubleSize', () => {
+		vpmController.BorderSizeX = 5;
+		const result: number = vpmController.BorderSizeX;
+		expect(result).to.equal(0);
+	});
+
+	it('dummy Customization function: BorderSizeY', () => {
+		vpmController.BorderSizeY = 5;
+		const result: number = vpmController.BorderSizeY;
+		expect(result).to.equal(0);
+	});
+
+	it('dummy Customization function: WindowPosX', () => {
+		vpmController.WindowPosX = 5;
+		const result: number = vpmController.WindowPosX;
+		expect(result).to.equal(0);
+	});
+
+	it('dummy Customization function: WindowPosY', () => {
+		vpmController.WindowPosY = 5;
+		const result: number = vpmController.WindowPosY;
+		expect(result).to.equal(0);
+	});
+
+	it('dummy GameSetting function: HandleMechanics', () => {
+		vpmController.HandleMechanics = 1;
+		const result: number = vpmController.HandleMechanics;
+		expect(result).to.equal(0);
+	});
+
 });

--- a/lib/scripting/objects/vpm-controller.spec.ts
+++ b/lib/scripting/objects/vpm-controller.spec.ts
@@ -36,6 +36,7 @@ describe.only('The VpmController - VISUAL PINMAME COM OBJECT', () => {
 		vpmController = new VpmController(player);
 	});
 
+	//TODO this fails due module loader
 	it('should set and get GameName', () => {
 		const NAME: string = 'foo';
 		vpmController.GameName = NAME;

--- a/lib/scripting/objects/vpm-controller.spec.ts
+++ b/lib/scripting/objects/vpm-controller.spec.ts
@@ -26,7 +26,7 @@ import { VpmController } from './vpm-controller';
 
 /* tslint:disable:no-unused-expression no-string-literal */
 chai.use(require('sinon-chai'));
-describe('The VpmController - VISUAL PINMAME COM OBJECT', () => {
+describe.only('The VpmController - VISUAL PINMAME COM OBJECT', () => {
 
 	let vpmController: VpmController;
 
@@ -67,10 +67,30 @@ describe('The VpmController - VISUAL PINMAME COM OBJECT', () => {
 		expect(resultValue).to.equal(0.5);
 	});
 
-	it.skip('get Switch 0', () => {
+	it('get Switch 0', () => {
 		const result = vpmController.Switch[0];
 		expect(result).to.deep.equal(0);
 	});
 
+	it.skip('set Switch 0', () => {
+		vpmController.Switch[0] = 5;
+		const result = vpmController.Switch[0];
+		expect(result).to.deep.equal(5);
+	});
+
+	it('get Lamp 0', () => {
+		const result = vpmController.Lamp[0];
+		expect(result).to.deep.equal(0);
+	});
+
+	it('get Solenoid 0', () => {
+		const result = vpmController.Solenoid[0];
+		expect(result).to.deep.equal(0);
+	});
+
+	it('get GIString 0', () => {
+		const result = vpmController.GIString[0];
+		expect(result).to.deep.equal(0);
+	});
 
 });

--- a/lib/scripting/objects/vpm-controller.spec.ts
+++ b/lib/scripting/objects/vpm-controller.spec.ts
@@ -26,7 +26,7 @@ import { VpmController } from './vpm-controller';
 
 /* tslint:disable:no-unused-expression no-string-literal */
 chai.use(require('sinon-chai'));
-describe.only('The VpmController - VISUAL PINMAME COM OBJECT', () => {
+describe('The VpmController - VISUAL PINMAME COM OBJECT', () => {
 
 	let vpmController: VpmController;
 
@@ -36,11 +36,31 @@ describe.only('The VpmController - VISUAL PINMAME COM OBJECT', () => {
 		vpmController = new VpmController(player);
 	});
 
-	//TODO this fails due module loader
+	//TODO this fails due wpc-emu module loader
 	it('should set and get GameName', () => {
 		const NAME: string = 'foo';
 		vpmController.GameName = NAME;
 		expect(vpmController.GameName).to.equal(NAME);
+	});
+
+	it('should set and get pause state', () => {
+		vpmController.Pause = true;
+		expect(vpmController.Pause).to.equal(true);
+	});
+
+	it('should not run when paused', () => {
+		vpmController.Pause = true;
+		expect(vpmController.Running).to.equal(false);
+	});
+
+	it('should not run when emu is not initialized', () => {
+		vpmController.Pause = false;
+		expect(vpmController.Running).to.equal(false);
+	});
+
+	it('should Stop', () => {
+		vpmController.Stop();
+		expect(vpmController.Running).to.equal(false);
 	});
 
 	it('should set and get Dip[0]', () => {
@@ -60,12 +80,35 @@ describe.only('The VpmController - VISUAL PINMAME COM OBJECT', () => {
 		expect(result).to.deep.equal([]);
 	});
 
-	it.skip('should return one changed lamp', () => {
-		const resultIndex = vpmController.ChangedLamps[0][0];
-		const resultValue = vpmController.ChangedLamps[0][1];
-		expect(resultIndex).to.equal(42);
-		//TODO unclear if uint8 or float type
-		expect(resultValue).to.equal(0.5);
+	it('no changed solenoid detected', () => {
+		const result = vpmController.ChangedSolenoids;
+		expect(result).to.deep.equal([]);
+	});
+
+	it('no changed GI detected', () => {
+		const result = vpmController.ChangedGI;
+		expect(result).to.deep.equal([]);
+	});
+
+	it('no changed LEDs detected', () => {
+		const result = vpmController.ChangedLEDs;
+		expect(result).to.deep.equal([]);
+	});
+
+	it('should ignore writes to RO settings', () => {
+		vpmController.Solenoid[0] = 1;
+		vpmController.Lamp[0] = 1;
+		vpmController.GIString[0] = 1;
+		vpmController.Switch[0] = 1;
+		expect(vpmController.Solenoid[0]).to.equal(0);
+	});
+
+	it('should ignore calls to Customization functions', () => {
+		vpmController.SetDisplayPosition(1, 2, 3);
+		vpmController.ShowOptsDialog(3);
+		vpmController.ShowPathesDialog(3);
+		const foo = vpmController.ShowAboutDialog(3);
+		expect(foo).to.equal(undefined);
 	});
 
 	it('get Switch 0', () => {
@@ -102,6 +145,16 @@ describe.only('The VpmController - VISUAL PINMAME COM OBJECT', () => {
 	it('get SampleRate', () => {
 		const result: number = vpmController.SampleRate;
 		expect(result).to.equal(22050);
+	});
+
+	it('CheckROMS()', () => {
+		const result: boolean = vpmController.CheckROMS(1);
+		expect(result).to.equal(true);
+	});
+
+	it('get Version', () => {
+		const result: string = vpmController.Version;
+		expect(result).to.equal('00990201');
 	});
 
 	it('set and get SplashInfoLine', () => {

--- a/lib/scripting/objects/vpm-controller.spec.ts
+++ b/lib/scripting/objects/vpm-controller.spec.ts
@@ -54,4 +54,18 @@ describe('The VpmController - VISUAL PINMAME COM OBJECT', () => {
 		expect(vpmController.Dip[40]).to.equal(VALUE);
 	});
 
+	it.skip('no changed lamps detected', () => {
+		const result = vpmController.ChangedLamps;
+		expect(result).to.deep.equal([]);
+	});
+
+	it.skip('should return one changed lamp', () => {
+		const resultIndex = vpmController.ChangedLamps[0][0];
+		const resultValue = vpmController.ChangedLamps[0][1];
+		expect(resultIndex).to.equal(42);
+		//TODO unclear if uint8 or float type
+		expect(resultValue).to.equal(0.5);
+	});
+
+
 });

--- a/lib/scripting/objects/vpm-controller.ts
+++ b/lib/scripting/objects/vpm-controller.ts
@@ -266,8 +266,13 @@ export class VpmController {
 				return this.emulator.emulatorState.getSwitchState(prop);
 			},
 
-			set: (target: {[ index: number ]: number}, prop: number, value: number): boolean => {
+			set: (target: {[ index: number ]: number}, prop: number | string, value: number): boolean => {
 				logger().debug('SET SWITCH', {target, prop, value});
+				if (value) {
+					this.emulator.setInput(parseInt(prop.toString(), 10));
+				} else {
+					logger().debug('CLEAR SWITCH IGNORED!', {target, prop, value});
+				}
 /*
 				TODO implement this to the backend
 				23:54:23.544 logger.js:30 SET SWITCH {target: {…}, prop: "24", value: 0}
@@ -278,7 +283,6 @@ export class VpmController {
 				23:54:23.545 logger.js:30 SET SWITCH {target: {…}, prop: "36", value: 1}
 				23:54:23.545 logger.js:30 SET SWITCH {target: {…}, prop: "38", value: 1}
 */
-				this.emulator.setInput(value);
 				return true;
 			},
 		};

--- a/lib/scripting/objects/vpm-controller.ts
+++ b/lib/scripting/objects/vpm-controller.ts
@@ -67,12 +67,12 @@ export class VpmController {
 			})
 			.then(() => {
 				setInterval(() => {
-					this.emulator.executeCycleForTime(200);
+					this.emulator.emuSimulateCycle(200);
 				}, 200);
 			})
 			.catch((error) => {
 				logger().error('ERROR FAILED', error.messages);
-			})
+			});
 	}
 	get Running(): boolean {
 		return this.emulator && !this.paused;

--- a/lib/scripting/objects/vpm-controller.ts
+++ b/lib/scripting/objects/vpm-controller.ts
@@ -59,6 +59,7 @@ export class VpmController {
 	set GameName(gameName: string) {
 		this.gameName = gameName;
 		logger().debug('GAMENAME:', gameName);
+		//TODO this is hardwired to test
 		getGameEntry(gameName)
 			.then((answer: LoadedGameEntry) => {
 				logger().info('LOADED', answer.wpcDbEntry);
@@ -192,7 +193,8 @@ export class VpmController {
 
 	// AggregatePollingFunctions
 	get ChangedLamps() {
-		return [ 0 ];
+		logger().debug('ChangedLamps');
+		return [ [10, 1], [20, 1] ];
 	}
 	get ChangedSolenoids() {
 		return [ 0 ];
@@ -206,6 +208,7 @@ export class VpmController {
 
 	// GameInputOutput TODO need a proxy handle
 	get Lamp() {
+		logger().debug('get Lamp');
 		return 0;
 	}
 	get Solenoid() {

--- a/lib/scripting/objects/vpm-controller.ts
+++ b/lib/scripting/objects/vpm-controller.ts
@@ -67,12 +67,6 @@ export class VpmController {
 			})
 			.then(() => {
 				this.player.setEmulator(this.emulator);
-
-				//TODO HACK - used to launch the rom
-				setTimeout(() => {
-					console.log('MANUAL KICK ROMS BUTT!');
-					this.emulator.setCabinetInput(16);
-				}, 3000);
 			})
 			.catch((error) => {
 				logger().error('ERROR FAILED', error.messages);
@@ -199,7 +193,7 @@ export class VpmController {
 	get ChangedLamps(): number[][] {
 		const changedLamps: number[][] = this.emulator.emulatorState.getChangedLamps();
 		if (changedLamps.length > 0) {
-			logger().debug('ChangedLamps', changedLamps);
+		//	logger().debug('ChangedLamps', changedLamps);
 		}
 		return changedLamps;
 	}

--- a/lib/scripting/objects/vpm-controller.ts
+++ b/lib/scripting/objects/vpm-controller.ts
@@ -123,9 +123,11 @@ export class VpmController {
 	 * non WPCnumbering = 1,2,3,4,...
 	 */
 	get WPCNumbering(): number {
+		logger().debug('WPCNumbering');
 		return 1;
 	}
 	get SampleRate(): number {
+		logger().debug('SampleRate');
 		return 22050;
 	}
 

--- a/lib/scripting/objects/vpm-controller.ts
+++ b/lib/scripting/objects/vpm-controller.ts
@@ -194,18 +194,18 @@ export class VpmController {
 	}
 
 	// AggregatePollingFunctions
-	get ChangedLamps() {
+	get ChangedLamps(): number[][] {
 		logger().debug('ChangedLamps');
-		return [ [10, 1], [20, 1] ];
+		return this.emulator.emulatorState.getChangedLamps();
 	}
-	get ChangedSolenoids() {
-		return [ 0 ];
+	get ChangedSolenoids(): number[][] {
+		return this.emulator.emulatorState.getChangedSolenoids();
 	}
-	get ChangedGI() {
-		return [ 0 ];
+	get ChangedGI(): number[][] {
+		return this.emulator.emulatorState.getChangedGI();
 	}
-	get ChangedLEDs() {
-		return [ 0 ];
+	get ChangedLEDs(): number[][] {
+		return this.emulator.emulatorState.ChangedLEDs();
 	}
 
 	// GameInputOutput TODO need a proxy handle

--- a/lib/scripting/objects/vpm-controller.ts
+++ b/lib/scripting/objects/vpm-controller.ts
@@ -204,9 +204,6 @@ export class VpmController {
 	// AggregatePollingFunctions
 	get ChangedLamps(): number[][] {
 		const changedLamps: number[][] = this.emulator.emulatorState.getChangedLamps();
-		if (changedLamps.length > 0) {
-		//	logger().debug('ChangedLamps', changedLamps);
-		}
 		return changedLamps;
 	}
 	get ChangedSolenoids(): number[][] {

--- a/lib/scripting/objects/vpm-controller.ts
+++ b/lib/scripting/objects/vpm-controller.ts
@@ -117,8 +117,13 @@ export class VpmController {
 	set HandleMechanics(mechanicNr: number) {
 		logger().debug('HandleMechanics');
 	}
+	/**
+	 * Determine if game uses WPC Numbering of Switches and Lamps
+	 * WPCNumbering = Column*10 + Row (11,12,13,14,15,16,17,18,21,22...)
+	 * non WPCnumbering = 1,2,3,4,...
+	 */
 	get WPCNumbering(): number {
-		return 0;
+		return 1;
 	}
 	get SampleRate(): number {
 		return 22050;

--- a/lib/scripting/objects/vpm-controller.ts
+++ b/lib/scripting/objects/vpm-controller.ts
@@ -246,13 +246,13 @@ export class VpmController {
 	private createDipGetter(): { [index: number]: number } {
 		const handler = {
 			get: (target: {[ index: number ]: number}, prop: number): number => {
-				logger().debug('GET', {target, prop});
+				logger().debug('GETDIP', {target, prop});
 				return prop in target ? target[prop] : 0;
 			},
 
 			set: (target: {[ index: number ]: number}, prop: number, value: number): boolean => {
 				target[prop] = value;
-				logger().debug('SET', {target, prop, value});
+				logger().debug('SETDIP', {target, prop, value});
 				return true;
 			},
 		};
@@ -267,7 +267,7 @@ export class VpmController {
 			},
 
 			set: (target: {[ index: number ]: number}, prop: number | string, value: number): boolean => {
-				logger().debug('SET SWITCH', {target, prop, value});
+				logger().debug('SET SWITCH', {target, prop, value, type: typeof prop});
 				if (value) {
 					this.emulator.setInput(parseInt(prop.toString(), 10));
 				} else {

--- a/lib/scripting/objects/vpm-controller.ts
+++ b/lib/scripting/objects/vpm-controller.ts
@@ -20,8 +20,8 @@
 
 import { Player } from '../../game/player';
 import { logger } from '../../util/logger';
-import { Emulator } from './pinball-backend/wpc-emu';
 import { getGameEntry } from './pinball-backend/rom-fetcher';
+import { Emulator } from './pinball-backend/wpc-emu';
 
 /**
  * Implementation of the VISUAL PINMAME COM OBJECT PROPERTY/METHOD

--- a/lib/scripting/objects/vpm-controller.ts
+++ b/lib/scripting/objects/vpm-controller.ts
@@ -51,6 +51,7 @@ export class VpmController {
 		this.splashInfoLine = '';
 		this.paused = false;
 		this.emulator = new Emulator();
+		// TODO route this to the emu
 		this.Dip = this.createDipGetter();
 		this.Switch = this.createGetSetBooleanProxy('SWITCH',
 			(index) => this.emulator.getSwitchInput(index), (switchNr, value) => this.emulator.setSwitchInput(switchNr, value));

--- a/lib/scripting/objects/vpm-controller.ts
+++ b/lib/scripting/objects/vpm-controller.ts
@@ -85,7 +85,7 @@ export class VpmController {
 			});
 	}
 	get Running(): boolean {
-		return this.emulator && !this.paused;
+		return this.paused !== true && this.emulator.isInitialized();
 	}
 	get Pause(): boolean {
 		return this.paused;
@@ -93,10 +93,14 @@ export class VpmController {
 	set Pause(paused: boolean) {
 		this.paused = paused;
 	}
+	/**
+	 * Returns the version number of Visual PinMAME as an 8-digit string "vvmmbbrr":
+	 * Example: A result of "00990201" signifies "Version 0.99 Beta 2 Rev A
+	 *
+	 */
 	get Version(): string {
-		return this.emulator.getVersion();
+		return '00990201';
 	}
-	//TODO return value
 	public Run() {
 		logger().debug('RUN', this.gameName);
 		if (this.gameName) {
@@ -205,8 +209,14 @@ export class VpmController {
 	public ShowAboutDialog(hWnd: any): void {
 		logger().debug('ShowAboutDialog', hWnd);
 	}
-	public CheckROMS(nShowOptions: number, hWnd: any): void {
-		logger().debug('CheckROMS', nShowOptions, hWnd);
+	/**
+	 * Checks the rom set for the current game and displays the results.
+	 * @param nShowOptions: 0 = Always displays the results, 1 = Only displays the results if there are errors found, 2 = Never displays the results
+	 * @returns true if the roms are good.
+	 */
+	public CheckROMS(nShowOptions: number): boolean {
+		logger().debug('CheckROMS', nShowOptions);
+		return true;
 	}
 
 	// AggregatePollingFunctions

--- a/lib/scripting/objects/vpm-controller.ts
+++ b/lib/scripting/objects/vpm-controller.ts
@@ -36,7 +36,7 @@ export class VpmController {
 	private gameName: string;
 	private splashInfoLine: string;
 	private paused: boolean;
-	public Dip: { [index: number]: number };
+	public readonly Dip: { [index: number]: number };
 
 	//private gameRomInfoPromise: Promise<Response>;
 

--- a/lib/scripting/objects/vpm-controller.ts
+++ b/lib/scripting/objects/vpm-controller.ts
@@ -97,8 +97,8 @@ export class VpmController {
 		return this.emulator.getVersion();
 	}
 	//TODO return value
-	public Run(parentWindow: any, minVersion: number) {
-		logger().debug('RUN', parentWindow, minVersion);
+	public Run() {
+		logger().debug('RUN', this.gameName);
 		if (this.gameName) {
 			// TODO: fetch rom from vpdb.io here
 			//return this.emulator.loadGame(this.gameName);
@@ -111,11 +111,12 @@ export class VpmController {
 
 	// GameSetting
 	// NOTE: Dip - implemented using Proxy
+
 	get HandleMechanics(): number {
 		return 0;
 	}
 	set HandleMechanics(mechanicNr: number) {
-		logger().debug('HandleMechanics');
+		logger().debug('TODO HandleMechanics');
 	}
 	/**
 	 * Determine if game uses WPC Numbering of Switches and Lamps
@@ -259,8 +260,7 @@ export class VpmController {
 		return new Proxy<{ [index: number ]: number; }>({}, handler);
 	}
 
-	private createGetSetNumberProxy(
-			name: string,
+	private createGetSetNumberProxy(name: string,
 			getFunction: (prop: number) => number,
 			setFunction: (prop: number, value: number) => boolean,
 		): { [index: number]: number } {
@@ -278,8 +278,7 @@ export class VpmController {
 		return new Proxy<{ [index: number ]: number; }>({}, handler);
 	}
 
-	private createGetSetBooleanProxy(
-		name: string,
+	private createGetSetBooleanProxy(name: string,
 		getFunction: (prop: number) => number,
 		setFunction: (prop: number, value: boolean) => boolean,
 	): { [index: number]: number } {

--- a/lib/scripting/objects/vpm-controller.ts
+++ b/lib/scripting/objects/vpm-controller.ts
@@ -268,6 +268,16 @@ export class VpmController {
 
 			set: (target: {[ index: number ]: number}, prop: number, value: number): boolean => {
 				logger().debug('SET SWITCH', {target, prop, value});
+/*
+				TODO implement this to the backend
+				23:54:23.544 logger.js:30 SET SWITCH {target: {…}, prop: "24", value: 0}
+				23:54:23.544 logger.js:30 SET SWITCH {target: {…}, prop: "32", value: 1}
+				23:54:23.544 logger.js:30 SET SWITCH {target: {…}, prop: "33", value: 1}
+				23:54:23.545 logger.js:30 SET SWITCH {target: {…}, prop: "34", value: 1}
+				23:54:23.545 logger.js:30 SET SWITCH {target: {…}, prop: "35", value: 1}
+				23:54:23.545 logger.js:30 SET SWITCH {target: {…}, prop: "36", value: 1}
+				23:54:23.545 logger.js:30 SET SWITCH {target: {…}, prop: "38", value: 1}
+*/
 				this.emulator.setInput(value);
 				return true;
 			},

--- a/lib/scripting/objects/vpm-controller.ts
+++ b/lib/scripting/objects/vpm-controller.ts
@@ -20,7 +20,7 @@
 
 import { Player } from '../../game/player';
 import { logger } from '../../util/logger';
-import { getGameEntry, LoadedGameEntry } from './pinball-backend/rom-fetcher';
+import { downloadGameEntry, LoadedGameEntry } from './pinball-backend/rom-fetcher';
 import { Emulator } from './pinball-backend/wpc-emu';
 
 /**
@@ -72,7 +72,7 @@ export class VpmController {
 		this.gameName = gameName;
 		logger().debug('GAMENAME:', gameName);
 		//TODO this is hardwired to test
-		getGameEntry(gameName)
+		downloadGameEntry(gameName)
 			.then((answer: LoadedGameEntry) => {
 				logger().info('LOADED', answer.wpcDbEntry);
 				return this.emulator.loadGame(answer.wpcDbEntry, answer.romFile);

--- a/lib/scripting/objects/vpm-controller.ts
+++ b/lib/scripting/objects/vpm-controller.ts
@@ -66,6 +66,8 @@ export class VpmController {
 				return this.emulator.loadGame(answer.wpcDbEntry, answer.romFile);
 			})
 			.then(() => {
+				// TODO enable me
+				//this.player.setEmulator(this.emulator);
 				setInterval(() => {
 					this.emulator.emuSimulateCycle(200);
 				}, 200);

--- a/lib/scripting/objects/vpm-controller.ts
+++ b/lib/scripting/objects/vpm-controller.ts
@@ -290,4 +290,3 @@ export class VpmController {
 	}
 
 }
-

--- a/lib/scripting/objects/vpm-controller.ts
+++ b/lib/scripting/objects/vpm-controller.ts
@@ -66,11 +66,13 @@ export class VpmController {
 				return this.emulator.loadGame(answer.wpcDbEntry, answer.romFile);
 			})
 			.then(() => {
-				// TODO enable me
-				//this.player.setEmulator(this.emulator);
-				setInterval(() => {
-					this.emulator.emuSimulateCycle(200);
-				}, 200);
+				this.player.setEmulator(this.emulator);
+
+				//TODO HACK - used to launch the rom
+				setTimeout(() => {
+					console.log('MANUAL KICK ROMS BUTT!');
+					this.emulator.setCabinetInput(16);
+				}, 3000);
 			})
 			.catch((error) => {
 				logger().error('ERROR FAILED', error.messages);
@@ -195,8 +197,11 @@ export class VpmController {
 
 	// AggregatePollingFunctions
 	get ChangedLamps(): number[][] {
-		logger().debug('ChangedLamps');
-		return this.emulator.emulatorState.getChangedLamps();
+		const changedLamps: number[][] = this.emulator.emulatorState.getChangedLamps();
+		if (changedLamps.length > 0) {
+			logger().debug('ChangedLamps', changedLamps);
+		}
+		return changedLamps;
 	}
 	get ChangedSolenoids(): number[][] {
 		return this.emulator.emulatorState.getChangedSolenoids();

--- a/lib/scripting/objects/vpm-controller.ts
+++ b/lib/scripting/objects/vpm-controller.ts
@@ -20,7 +20,7 @@
 
 import { Player } from '../../game/player';
 import { logger } from '../../util/logger';
-import { getGameEntry } from './pinball-backend/rom-fetcher';
+import { getGameEntry, LoadedGameEntry } from './pinball-backend/rom-fetcher';
 import { Emulator } from './pinball-backend/wpc-emu';
 
 /**
@@ -59,7 +59,19 @@ export class VpmController {
 	set GameName(gameName: string) {
 		this.gameName = gameName;
 		logger().debug('GAMENAME:', gameName);
-		getGameEntry(gameName);
+		getGameEntry(gameName)
+			.then((answer: LoadedGameEntry) => {
+				logger().info('LOADED', answer.wpcDbEntry);
+				return this.emulator.loadGame(answer.wpcDbEntry, answer.romFile);
+			})
+			.then(() => {
+				setInterval(() => {
+					this.emulator.executeCycleForTime(200);
+				}, 200);
+			})
+			.catch((error) => {
+				logger().error('ERROR FAILED', error.messages);
+			})
 	}
 	get Running(): boolean {
 		return this.emulator && !this.paused;
@@ -78,7 +90,7 @@ export class VpmController {
 		logger().debug('RUN', parentWindow, minVersion);
 		if (this.gameName) {
 			// TODO: fetch rom from vpdb.io here
-			return this.emulator.loadGame(this.gameName);
+			//return this.emulator.loadGame(this.gameName);
 		}
 	}
 	public Stop(): void {

--- a/lib/scripting/objects/vpm-controller.ts
+++ b/lib/scripting/objects/vpm-controller.ts
@@ -45,7 +45,6 @@ export class VpmController {
 	//private gameRomInfoPromise: Promise<Response>;
 
 	constructor(player: Player) {
-		logger().debug('HELLO FROM VPM CONTROLLER');
 		this.player = player;
 		this.gameName = '';
 		this.splashInfoLine = '';

--- a/lib/tslint.json
+++ b/lib/tslint.json
@@ -1,7 +1,7 @@
 {
 	"extends": "tslint:recommended",
 	"linterOptions": {
-		"exclude": [ "**/*.js", "**/vbscript.ts", "**/vendor/**" ]
+		"exclude": [ "**/*.js", "**/vbscript.ts", "**/vendor/**", "../coverage/**/*" ]
 	},
 	"rules": {
 		"quotemark": [ true, "single", "avoid-escape" ],

--- a/lib/vpt/light/light-mesh.spec.ts
+++ b/lib/vpt/light/light-mesh.spec.ts
@@ -24,6 +24,7 @@ import { NodeBinaryReader } from '../../io/binary-reader.node';
 import { SpotLight } from '../../refs.node';
 import { Table } from '../table/table';
 import { TableExporter } from '../table/table-exporter';
+import { ThreeLightGenerator } from '../../render/threejs/three-light-generator';
 
 const three = new ThreeHelper();
 const scale = 0.05;
@@ -67,7 +68,7 @@ describe('The VPinball lights generator', () => {
 	it('should generate a light with default parameters', async () => {
 		const light = three.find<SpotLight>(gltf, 'lightBulbs', 'StaticBulb', 'light');
 		expect(light.decay).to.equal(2);
-		expect(light.intensity).to.equal(1);
+		expect(light.intensity).to.equal(ThreeLightGenerator.BULB_FACTOR);
 		expect(light.distance).to.equal(scale * 50);
 		expect(light.color.r).to.equal(1);
 		expect(light.color.g).to.equal(1);
@@ -77,8 +78,8 @@ describe('The VPinball lights generator', () => {
 	it('should generate a light with custom parameters', async () => {
 		const light = three.find<SpotLight>(gltf, 'lightBulbs', 'CustomParams', 'light');
 		expect(light.decay).to.equal(2);
-		expect(Math.round(light.intensity * 1000) / 1000).to.equal(5.2);
-		expect(Math.round(light.distance * 1000) / 1000).to.equal(scale * 64.1);
+		expect(light.intensity).to.be.closeTo(5.2 * ThreeLightGenerator.BULB_FACTOR, 0.0001);
+		expect(light.distance).to.be.closeTo(scale * 64.1, 0.0001);
 		expect(light.color.r).to.equal(0.34901960784313724);
 		expect(light.color.g).to.equal(0.9333333333333333);
 		expect(light.color.b).to.equal(0.06666666666666667);

--- a/lib/vpt/light/light-updater.ts
+++ b/lib/vpt/light/light-updater.ts
@@ -33,6 +33,10 @@ export class LightUpdater extends ItemUpdater<LightState> {
 	}
 
 	public applyState<NODE, GEOMETRY, POINT_LIGHT>(obj: NODE, state: LightState, renderApi: IRenderApi<NODE, GEOMETRY, POINT_LIGHT>, table: Table): void {
-		renderApi.applyLighting(state, this.data.intensity, obj);
+
+		// update local state
+		Object.assign(this.state, state);
+
+		renderApi.applyLighting(this.state, this.data.intensity, obj);
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4656,8 +4656,8 @@
 			"dev": true
 		},
 		"wpc-emu": {
-			"version": "github:neophob/wpc-emu#e61815258c6711b9c58bc6bcfd587dcded3177a5",
-			"from": "github:neophob/wpc-emu#e61815258c6711b9c58bc6bcfd587dcded3177a5",
+			"version": "github:neophob/wpc-emu#43d2ebceec5a9d19941fd06af0288c46789c54c6",
+			"from": "github:neophob/wpc-emu#43d2ebceec5a9d19941fd06af0288c46789c54c6",
 			"requires": {
 				"debug": "^4.1.1"
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -4655,6 +4655,23 @@
 			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
 			"dev": true
 		},
+		"wpc-emu": {
+			"version": "github:neophob/wpc-emu#e0103dc602cb109dd4b9172b9de5ddb418e8e07a",
+			"from": "github:neophob/wpc-emu#e0103dc602cb109dd4b9172b9de5ddb418e8e07a",
+			"requires": {
+				"debug": "^4.1.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				}
+			}
+		},
 		"wrap-ansi": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4656,8 +4656,8 @@
 			"dev": true
 		},
 		"wpc-emu": {
-			"version": "github:neophob/wpc-emu#e0103dc602cb109dd4b9172b9de5ddb418e8e07a",
-			"from": "github:neophob/wpc-emu#e0103dc602cb109dd4b9172b9de5ddb418e8e07a",
+			"version": "github:neophob/wpc-emu#1e97e208264b19c3f339e5bc1480cdc52c5fb48a",
+			"from": "github:neophob/wpc-emu#1e97e208264b19c3f339e5bc1480cdc52c5fb48a",
 			"requires": {
 				"debug": "^4.1.1"
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -4656,8 +4656,8 @@
 			"dev": true
 		},
 		"wpc-emu": {
-			"version": "github:neophob/wpc-emu#1e97e208264b19c3f339e5bc1480cdc52c5fb48a",
-			"from": "github:neophob/wpc-emu#1e97e208264b19c3f339e5bc1480cdc52c5fb48a",
+			"version": "github:neophob/wpc-emu#e61815258c6711b9c58bc6bcfd587dcded3177a5",
+			"from": "github:neophob/wpc-emu#e61815258c6711b9c58bc6bcfd587dcded3177a5",
 			"requires": {
 				"debug": "^4.1.1"
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -2426,6 +2426,12 @@
 			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
 			"dev": true
 		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
+		},
 		"jsonfile": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -3014,6 +3020,31 @@
 				"path-to-regexp": "^1.7.0"
 			}
 		},
+		"nock": {
+			"version": "11.7.0",
+			"resolved": "https://registry.npmjs.org/nock/-/nock-11.7.0.tgz",
+			"integrity": "sha512-7c1jhHew74C33OBeRYyQENT+YXQiejpwIrEjinh6dRurBae+Ei4QjeUaPlkptIF0ZacEiVCnw8dWaxqepkiihg==",
+			"dev": true,
+			"requires": {
+				"chai": "^4.1.2",
+				"debug": "^4.1.0",
+				"json-stringify-safe": "^5.0.1",
+				"lodash": "^4.17.13",
+				"mkdirp": "^0.5.0",
+				"propagate": "^2.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				}
+			}
+		},
 		"node-abi": {
 			"version": "2.10.0",
 			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.10.0.tgz",
@@ -3037,6 +3068,12 @@
 				"object.getownpropertydescriptors": "^2.0.3",
 				"semver": "^5.7.0"
 			}
+		},
+		"node-fetch": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+			"dev": true
 		},
 		"node-gyp-build": {
 			"version": "3.9.0",
@@ -3623,6 +3660,12 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
 			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+		},
+		"propagate": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+			"integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+			"dev": true
 		},
 		"proto-list": {
 			"version": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,8 @@
 		"microtime": "3.0.0",
 		"mocha": "6.2.2",
 		"nearley": "2.19.0",
+		"nock": "^11.7.0",
+		"node-fetch": "^2.6.0",
 		"nyc": "14.1.1",
 		"rimraf": "3.0.0",
 		"sinon": "7.5.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"sharp": "^0.23.0",
 		"text-encoding": "^0.7.0",
 		"three": "^0.109.0",
-		"wpc-emu": "github:neophob/wpc-emu#e61815258c6711b9c58bc6bcfd587dcded3177a5"
+		"wpc-emu": "github:neophob/wpc-emu#43d2ebceec5a9d19941fd06af0288c46789c54c6"
 	},
 	"devDependencies": {
 		"@types/chai": "4.2.4",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
 		"pngquant": "^3.0.0",
 		"sharp": "^0.23.0",
 		"text-encoding": "^0.7.0",
-		"three": "^0.109.0"
+		"three": "^0.109.0",
+		"wpc-emu": "github:neophob/wpc-emu#e0103dc602cb109dd4b9172b9de5ddb418e8e07a"
 	},
 	"devDependencies": {
 		"@types/chai": "4.2.4",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"sharp": "^0.23.0",
 		"text-encoding": "^0.7.0",
 		"three": "^0.109.0",
-		"wpc-emu": "github:neophob/wpc-emu#1e97e208264b19c3f339e5bc1480cdc52c5fb48a"
+		"wpc-emu": "github:neophob/wpc-emu#e61815258c6711b9c58bc6bcfd587dcded3177a5"
 	},
 	"devDependencies": {
 		"@types/chai": "4.2.4",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"sharp": "^0.23.0",
 		"text-encoding": "^0.7.0",
 		"three": "^0.109.0",
-		"wpc-emu": "github:neophob/wpc-emu#e0103dc602cb109dd4b9172b9de5ddb418e8e07a"
+		"wpc-emu": "github:neophob/wpc-emu#1e97e208264b19c3f339e5bc1480cdc52c5fb48a"
 	},
 	"devDependencies": {
 		"@types/chai": "4.2.4",


### PR DESCRIPTION
Implements #124 , details:

Implemented:
- emuStep(howManyMsPassed)
- wpc-emu websocket decoupled - we can use the api for the main thread but there is also an API for - within the webworker
- typescript exports implemented for all api's
- write adapter between "VISUAL PINMAME COM OBJECT" and WPC-EMU (see https://github.com/vpdb/vpx-js/blob/feature/wpc/lib/scripting/objects/API.md). VpmController needs to expose this api and forward this to wpc emu
- create diff notification (send only changed Lamps, Solenoid, GI, LED)
- option to exclude "expensive state objects" like RAM, VideoRAM
- WPC-EMU, add function to set or clear a switch (only toggle was supported)
- grab rom from vpdb.io

Next steps, see #138 