### PR TITLE
Scripting: Fix event parsing

### DIFF
--- a/lib/scripting/transformer/event-transformer.spec.ts
+++ b/lib/scripting/transformer/event-transformer.spec.ts
@@ -20,8 +20,8 @@
 import * as chai from 'chai';
 import { expect } from 'chai';
 import { astToVbs, vbsToAst } from '../../../test/script.helper';
+import { TableBuilder } from '../../../test/table-builder';
 import { ThreeHelper } from '../../../test/three.helper';
-import { NodeBinaryReader } from '../../io/binary-reader.node';
 import { Table } from '../../vpt/table/table';
 import { EventTransformer } from './event-transformer';
 
@@ -33,14 +33,23 @@ describe('The scripting event transformer', () => {
 	const three = new ThreeHelper();
 	let table: Table;
 
-	before(async () => {
-		table = await Table.load(new NodeBinaryReader(three.fixturePath('table-gate.vpx')));
+	before(() => {
+		table = new TableBuilder()
+			.addGate('WireRectangle')
+			.addGate('Wire_Rectangle')
+			.build();
 	});
 
 	it('should transform a valid event on a valid item', () => {
 		const vbs = `Sub WireRectangle_Init()\nBallRelease.CreateBall\nEnd Sub\n`;
 		const js = transform(vbs, table);
 		expect(js).to.equal(`WireRectangle.on('Init', () => {\n    BallRelease.CreateBall();\n});`);
+	});
+
+	it('should transform a an item with an underscore in its name', () => {
+		const vbs = `Sub Wire_Rectangle_Init()\nBallRelease.CreateBall\nEnd Sub\n`;
+		const js = transform(vbs, table);
+		expect(js).to.equal(`Wire_Rectangle.on('Init', () => {\n    BallRelease.CreateBall();\n});`);
 	});
 
 	it('should not transform an invalid event on a valid item', () => {

--- a/lib/scripting/transformer/event-transformer.spec.ts
+++ b/lib/scripting/transformer/event-transformer.spec.ts
@@ -52,6 +52,13 @@ describe('The scripting event transformer', () => {
 		expect(js).to.equal(`Wire_Rectangle.on('Init', () => {\n    BallRelease.CreateBall();\n});`);
 	});
 
+	it('should transform when the event name has a different case', () => {
+		const vbs = `Sub WireRectangle_init()\nBallRelease.CreateBall\nEnd Sub\n`;
+		const js = transform(vbs, table);
+		expect(js).to.equal(`WireRectangle.on('Init', () => {\n    BallRelease.CreateBall();\n});`);
+	});
+
+
 	it('should not transform an invalid event on a valid item', () => {
 		const vbs = `Sub WireRectangle_DuhDah()\nBallRelease.CreateBall\nEnd Sub\n`;
 		const js = transform(vbs, table);

--- a/lib/scripting/transformer/event-transformer.ts
+++ b/lib/scripting/transformer/event-transformer.ts
@@ -75,7 +75,8 @@ export class EventTransformer extends Transformer {
 				}
 
 				// table item must support given event
-				if (!this.items[objName].getEventNames().includes(eventName)) {
+				const existingEventName = matchEventName(this.items[objName].getEventNames(), eventName);
+				if (!existingEventName) {
 					return node;
 				}
 
@@ -85,11 +86,19 @@ export class EventTransformer extends Transformer {
 						identifier('on'),
 					),
 					[
-						literal(eventName),
+						literal(existingEventName),
 						arrowFunctionExpression(false, functionNode.body, functionNode.params),
 					],
 				));
 			},
 		}) as Program;
+	}
+}
+
+function matchEventName(eventNames: string[], nameToMatch: string): string | undefined {
+	for (const eventName of eventNames) {
+		if (eventName.toLowerCase() === nameToMatch.toLowerCase()) {
+			return eventName;
+		}
 	}
 }

--- a/lib/scripting/transformer/event-transformer.ts
+++ b/lib/scripting/transformer/event-transformer.ts
@@ -61,10 +61,13 @@ export class EventTransformer extends Transformer {
 				}
 
 				// must have a _Event suffix
-				const [objName, eventName] = functionNode.id.name.split('_');
-				if (!eventName) {
+				if (!functionNode.id.name.includes('_')) {
 					return node;
 				}
+
+				// split on last index
+				const objName = functionNode.id.name.substr(0, functionNode.id.name.lastIndexOf('_'));
+				const eventName = functionNode.id.name.substr(functionNode.id.name.lastIndexOf('_') + 1);
 
 				// table item must exist
 				if (!this.items[objName]) {


### PR DESCRIPTION
There were two bugs:

- `Sub Some_Element_Event` would not get transformed to `Some_Element.on('Event', () => {})` because the event name would be parsed as `Element`
- `Sub SomeElement_event` would not get transformed because `event` wouldn't match the element's `Event` event.

This PR fixes both issues.