### PR TITLE
Add a progress log

### DIFF
--- a/lib/render/threejs/three-map-generator.ts
+++ b/lib/render/threejs/three-map-generator.ts
@@ -18,7 +18,7 @@
  */
 
 import { Texture as ThreeTexture } from '../../refs.node';
-import { logger } from '../../util/logger';
+import { logger, progress } from '../../util/logger';
 import { Table } from '../../vpt/table/table';
 import { Texture } from '../../vpt/texture';
 import { ITextureLoader } from '../irender-api';
@@ -41,6 +41,7 @@ export class ThreeMapGenerator {
 		for (const texture of textures) {
 			try {
 				this.textureCache.set(texture.getName(), await texture.loadTexture(this.textureLoader, table));
+				progress().details(texture.getName());
 			} catch (err) {
 				logger().warn('[ThreeMapGenerator.loadTextures] Error loading texture %s (%s/%s): %s', texture.getName(), texture.storageName, texture.getName(), err.message);
 			}

--- a/lib/render/threejs/three-render-api.ts
+++ b/lib/render/threejs/three-render-api.ts
@@ -20,6 +20,7 @@
 import { IRenderable, RenderInfo } from '../../game/irenderable';
 import { Matrix3D } from '../../math/matrix3d';
 import { BufferGeometry, Group, Matrix4, MeshStandardMaterial, Object3D, PointLight } from '../../refs.node';
+import { progress } from '../../util/logger';
 import { Pool } from '../../util/object-pool';
 import { ItemState } from '../../vpt/item-state';
 import { LightData } from '../../vpt/light/light-data';
@@ -70,6 +71,7 @@ export class ThreeRenderApi implements IRenderApi<Object3D, BufferGeometry, Poin
 	}
 
 	public async preloadTextures(textures: Texture[], table: Table): Promise<void> {
+		progress().show('Pre-loading textures');
 		await this.mapGenerator.loadTextures(textures, table);
 	}
 

--- a/lib/util/logger.ts
+++ b/lib/util/logger.ts
@@ -69,4 +69,30 @@ export interface ILogger {
 	debug(format: any, ...param: any[]): void;
 }
 
+export class Progress implements IProgress {
+	private static instance: IProgress = new Progress();
+
+	public static progress(): IProgress {
+		return Progress.instance;
+	}
+
+	public static setLogger(l: IProgress) {
+		Progress.instance = l;
+	}
+
+	public start(name: string, parent: string | null, format: any, ...param: any[]): void {
+		console.debug.apply(console.log, [ `[progress:${name}] ${format}`, ...param ]);
+	}
+
+	public end(name: string): void {
+	}
+
+}
+
+export interface IProgress {
+	start(name: string, parent: string | null, format: any, ...param: any[]): void;
+	end(name: string): void;
+}
+
 export const logger = Logger.logger;
+export const progress = Progress.progress;

--- a/lib/util/logger.ts
+++ b/lib/util/logger.ts
@@ -69,29 +69,87 @@ export interface ILogger {
 	debug(format: any, ...param: any[]): void;
 }
 
+/**
+ * The main purpose of this is to indicate in the UI that stuff is being
+ * processed.
+ *
+ * This is currently only used for loading the table, but could be used
+ * anywhere. Typically, calling `start` will pop up a progress dialog and
+ * show what's going on.
+ */
 export class Progress implements IProgress {
+
+	private currentTitle?: string;
+	private currentAction?: string;
+
 	private static instance: IProgress = new Progress();
 
+	/**
+	 * Get the global instance.
+	 */
 	public static progress(): IProgress {
 		return Progress.instance;
 	}
 
-	public static setLogger(l: IProgress) {
-		Progress.instance = l;
+	/**
+	 * Set a new global instance. The default instance, this class,
+	 * just dumps it to the console.
+	 * @param p
+	 */
+	public static setProgress(p: IProgress) {
+		Progress.instance = p;
 	}
 
-	public start(name: string, parent: string | null, format: any, ...param: any[]): void {
-		console.debug.apply(console.log, [ `[progress:${name}] ${format}`, ...param ]);
+	/**
+	 * Indicate the beginning of a new major operation. This is typically the
+	 * title of the progress dialog.
+	 * @param id ID of the operation.
+	 * @param title Displayed text
+	 */
+	public start(id: string, title: string): void {
+		this.currentTitle = title;
 	}
 
-	public end(name: string): void {
+	/**
+	 * Ends a previously started operation. All operation must end, otherwise
+	 * the progress dialog won't hide!
+	 * @param id ID of the operation
+	 */
+	public end(id: string): void {
 	}
 
+	/**
+	 * Show what's currently going on. This is usually displayed on one line,
+	 * where the action is left-aligned, and the details, if given, on the
+	 * right.
+	 *
+	 * @param action Text to display on the left
+	 * @param details Details on the right
+	 */
+	public show(action: string, details?: string): void {
+		this.currentAction = action;
+		this.print(details);
+	}
+
+	/**
+	 * Show a new detail for the current action. This only updates the text
+	 * on the "right" side.
+	 * @param details Details on the right
+	 */
+	public details(details: string): void {
+		this.print(details);
+	}
+
+	private print(details?: string) {
+		logger().error('%s: %s%s', this.currentTitle, this.currentAction, details ? ' (' + details + ')' : '');
+	}
 }
 
 export interface IProgress {
-	start(name: string, parent: string | null, format: any, ...param: any[]): void;
-	end(name: string): void;
+	start(id: string, title: string): void;
+	end(id: string): void;
+	show(action: string, details?: string): void;
+	details(details: string): void;
 }
 
 export const logger = Logger.logger;

--- a/lib/vpt/table/table-loader.ts
+++ b/lib/vpt/table/table-loader.ts
@@ -18,7 +18,7 @@
  */
 
 import { IBinaryReader, OleCompoundDoc, Storage } from '../../io/ole-doc';
-import { logger } from '../../util/logger';
+import { logger, progress } from '../../util/logger';
 import { Bumper } from '../bumper/bumper';
 import { Collection } from '../collection/collection';
 import { Decal } from '../decal/decal';
@@ -51,6 +51,7 @@ export class TableLoader {
 	private doc!: OleCompoundDoc;
 
 	public async load(reader: IBinaryReader, opts: TableLoadOptions = {}): Promise<LoadedTable> {
+		progress().start('table.load', 'table', 'Loading data from VPX file');
 		const then = Date.now();
 		this.doc = await OleCompoundDoc.load(reader);
 		try {
@@ -95,6 +96,7 @@ export class TableLoader {
 
 		} finally {
 			await this.doc.close();
+			progress().end('table.load');
 		}
 	}
 
@@ -133,6 +135,7 @@ export class TableLoader {
 
 		// go through all game items
 		for (let i = 0; i < numItems; i++) {
+			progress().start('table.load.item', 'table.load', `GameItem${i}`);
 			const itemName = `GameItem${i}`;
 			const itemData = await storage.read(itemName, 0, 4);
 			const itemType = itemData.readInt32LE(0);
@@ -145,6 +148,7 @@ export class TableLoader {
 			} else {
 				stats[ItemData.getType(itemType)]++;
 			}
+			progress().end('table.load.item');
 		}
 		return stats;
 	}
@@ -279,9 +283,11 @@ export class TableLoader {
 	private async loadTextures(loadedTable: LoadedTable, storage: Storage, numItems: number): Promise<void> {
 		loadedTable.textures = [];
 		for (let i = 0; i < numItems; i++) {
+			progress().start('table.load.texture', 'table.load', `Image${i}`);
 			const itemName = `Image${i}`;
 			const texture = await Texture.fromStorage(storage, itemName);
 			loadedTable.textures.push(texture);
+			progress().end('table.load.texture');
 		}
 	}
 

--- a/lib/vpt/table/table-loader.ts
+++ b/lib/vpt/table/table-loader.ts
@@ -51,7 +51,7 @@ export class TableLoader {
 	private doc!: OleCompoundDoc;
 
 	public async load(reader: IBinaryReader, opts: TableLoadOptions = {}): Promise<LoadedTable> {
-		progress().start('table.load', 'table', 'Loading data from VPX file');
+		progress().start('table.load', 'Loading VPX file');
 		const then = Date.now();
 		this.doc = await OleCompoundDoc.load(reader);
 		try {
@@ -134,13 +134,14 @@ export class TableLoader {
 		loadedTable.dispReels = [];
 
 		// go through all game items
+		progress().show('Loading game items');
 		for (let i = 0; i < numItems; i++) {
-			progress().start('table.load.item', 'table.load', `GameItem${i}`);
 			const itemName = `GameItem${i}`;
 			const itemData = await storage.read(itemName, 0, 4);
 			const itemType = itemData.readInt32LE(0);
 			const item = await this.loadItem(loadedTable, storage, itemName, itemType, opts);
 			if (item) {
+				progress().details(item.getName());
 				loadedTable.items[item.getName()] = item;
 			}
 			if (!stats[ItemData.getType(itemType)]) {
@@ -148,7 +149,6 @@ export class TableLoader {
 			} else {
 				stats[ItemData.getType(itemType)]++;
 			}
-			progress().end('table.load.item');
 		}
 		return stats;
 	}
@@ -281,13 +281,13 @@ export class TableLoader {
 	}
 
 	private async loadTextures(loadedTable: LoadedTable, storage: Storage, numItems: number): Promise<void> {
+		progress().show('Loading textures');
 		loadedTable.textures = [];
 		for (let i = 0; i < numItems; i++) {
-			progress().start('table.load.texture', 'table.load', `Image${i}`);
 			const itemName = `Image${i}`;
 			const texture = await Texture.fromStorage(storage, itemName);
 			loadedTable.textures.push(texture);
-			progress().end('table.load.texture');
+			progress().details(texture.getName());
 		}
 	}
 

--- a/lib/vpt/table/table-mesh-generator.ts
+++ b/lib/vpt/table/table-mesh-generator.ts
@@ -19,8 +19,8 @@
 
 /* tslint:disable:no-bitwise */
 import { IRenderable } from '../../game/irenderable';
-import { PointLightHelper } from '../../refs.node';
 import { IRenderApi } from '../../render/irender-api';
+import { progress } from '../../util/logger';
 import { Bumper } from '../bumper/bumper';
 import { Flipper } from '../flipper/flipper';
 import { ItemState } from '../item-state';
@@ -40,6 +40,7 @@ export class TableMeshGenerator {
 
 	public generateTableNode<NODE, GEOMETRY, POINT_LIGHT>(renderApi: IRenderApi<NODE, GEOMETRY, POINT_LIGHT>, opts: TableGenerateOptions = {}): NODE {
 
+		progress().show('Generating table nodes');
 		opts = Object.assign({}, defaultOptions, opts);
 		const tableNode = renderApi.createParentNode('playfield');
 		renderApi.transformScene(tableNode, this.table);
@@ -66,6 +67,7 @@ export class TableMeshGenerator {
 			if (!group.enabled) {
 				continue;
 			}
+			progress().details(group.name);
 			const itemTypeGroup = renderApi.createParentNode(group.name);
 			for (const renderable of group.meshes) {
 				const itemGroup = renderApi.createObjectFromRenderable(renderable, this.table, opts);

--- a/lib/vpt/table/table.ts
+++ b/lib/vpt/table/table.ts
@@ -34,7 +34,7 @@ import { HitObject } from '../../physics/hit-object';
 import { HitPlane } from '../../physics/hit-plane';
 import { IRenderApi } from '../../render/irender-api';
 import { Transpiler } from '../../scripting/transpiler';
-import { logger } from '../../util/logger';
+import { logger, progress } from '../../util/logger';
 import { Bumper } from '../bumper/bumper';
 import { Collection } from '../collection/collection';
 import { Decal } from '../decal/decal';
@@ -417,6 +417,7 @@ export class Table implements IScriptable<TableApi>, IRenderable<TableState> {
 			logger().warn('Table script is not loaded!');
 			return;
 		}
+		progress().show('Transpiling and executing table script');
 		const transpiler = new Transpiler(this, player);
 		transpiler.execute(this.tableScript, scope);
 		logger().info('Table script loaded, transpiled and executed.');

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -17,9 +17,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { Logger } from '../lib/util/logger';
+import { Logger, Progress } from '../lib/util/logger';
 
 before(() => {
+
 	// disable logging
 	Logger.setLogger({
 		debug(format: any, ...param: any[]): void {},
@@ -29,4 +30,12 @@ before(() => {
 		warn(format: any, ...param: any[]): void {},
 		wtf(format: any, ...param: any[]): void {}
 	});
+
+	// disable progress
+	Progress.setProgress({
+		details(details: string): void {},
+		end(id: string): void {},
+		show(action: string, details?: string): void {},
+		start(id: string, title: string): void {},
+	})
 });


### PR DESCRIPTION
Parsing the table can take some time, and the UI is showing nothing during that time.

This adds a progress interface which the host application can implement. It receives progress messages, currently only from table loading, scene creation and script transpilation. I might add a few more, but if they are only displayed a microsecond it's not really useful.

The application part is already done and will be pushed when this is merged.