### PR TITLE
Feature/support fliptronic flipper

### DIFF
--- a/lib/emu/wpc-emu.ts
+++ b/lib/emu/wpc-emu.ts
@@ -152,8 +152,7 @@ export class Emulator implements IEmulator {
 		if (!this.emulator) {
 			return;
 		}
-		//TODO support optionalEnableSwitch
-		this.emulator.setFliptronicsInput(value);
+		this.emulator.setFliptronicsInput(value, optionalEnableSwitch);
 	}
 
 	public getDmdDimensions(): Vertex2D {

--- a/lib/emu/wpc-emu.ts
+++ b/lib/emu/wpc-emu.ts
@@ -148,10 +148,11 @@ export class Emulator implements IEmulator {
 		this.emulator.setCabinetInput(value);
 	}
 
-	public setFliptronicsInput(value: string): void {
+	public setFliptronicsInput(value: string, optionalEnableSwitch?: boolean): void {
 		if (!this.emulator) {
 			return;
 		}
+		//TODO support optionalEnableSwitch
 		this.emulator.setFliptronicsInput(value);
 	}
 

--- a/lib/scripting/objects/vpm-controller.spec.ts
+++ b/lib/scripting/objects/vpm-controller.spec.ts
@@ -47,7 +47,7 @@ describe('The VpmController - VISUAL PINMAME COM OBJECT', () => {
 
 	afterEach(() => {
 		sandbox.restore();
-	  });
+	});
 
 	//TODO this fails due wpc-emu module loader
 	it('should set and get GameName', () => {

--- a/lib/scripting/objects/vpm-controller.spec.ts
+++ b/lib/scripting/objects/vpm-controller.spec.ts
@@ -29,7 +29,7 @@ import { VpmController } from './vpm-controller';
 
 /* tslint:disable:no-unused-expression no-string-literal */
 chai.use(require('sinon-chai'));
-describe('The VpmController - VISUAL PINMAME COM OBJECT', () => {
+describe.only('The VpmController - VISUAL PINMAME COM OBJECT', () => {
 
 	const sandbox = sinon.createSandbox();
 	let vpmController: VpmController;
@@ -135,6 +135,11 @@ describe('The VpmController - VISUAL PINMAME COM OBJECT', () => {
 	it('validate setSwitchInput is called with the correct settings, using 0 as input', () => {
 		vpmController.Switch[11] = 0;
 		expect(setSwitchInputSpy.args[0]).to.deep.equal([ 11, false ]);
+	});
+
+	it('validate setFliptronicsInput is called with the correct settings, using 0 as input', () => {
+		vpmController.Switch[112] = 0;
+		expect(setSwitchInputSpy.args[0]).to.deep.equal([ 112, false ]);
 	});
 
 	it('validate setSwitchInput is called with the correct settings, using true as input', () => {

--- a/lib/scripting/objects/vpm-controller.spec.ts
+++ b/lib/scripting/objects/vpm-controller.spec.ts
@@ -33,8 +33,8 @@ describe('The VpmController - VISUAL PINMAME COM OBJECT', () => {
 
 	const sandbox = sinon.createSandbox();
 	let vpmController: VpmController;
-	let setSwitchInputSpy: SinonStub<[number, (boolean | undefined)?]>;
-	let setFliptronicsInputSpy: SinonStub;
+	let setSwitchInputSpy: SinonStub<[number, boolean?]>;
+	let setFliptronicsInputSpy: SinonStub<[string, boolean?]>;
 
 	beforeEach(() => {
 		setSwitchInputSpy = sandbox.stub(Emulator.prototype, 'setSwitchInput').returns(true);
@@ -46,7 +46,7 @@ describe('The VpmController - VISUAL PINMAME COM OBJECT', () => {
 	});
 
 	afterEach(() => {
-		sandbox.restore()
+		sandbox.restore();
 	  });
 
 	//TODO this fails due wpc-emu module loader

--- a/lib/scripting/objects/vpm-controller.spec.ts
+++ b/lib/scripting/objects/vpm-controller.spec.ts
@@ -29,14 +29,16 @@ import { VpmController } from './vpm-controller';
 
 /* tslint:disable:no-unused-expression no-string-literal */
 chai.use(require('sinon-chai'));
-describe.only('The VpmController - VISUAL PINMAME COM OBJECT', () => {
+describe('The VpmController - VISUAL PINMAME COM OBJECT', () => {
 
 	const sandbox = sinon.createSandbox();
 	let vpmController: VpmController;
 	let setSwitchInputSpy: SinonStub<[number, (boolean | undefined)?]>;
+	let setFliptronicsInputSpy: SinonStub;
 
 	beforeEach(() => {
 		setSwitchInputSpy = sandbox.stub(Emulator.prototype, 'setSwitchInput').returns(true);
+		setFliptronicsInputSpy = sandbox.stub(Emulator.prototype, 'setFliptronicsInput');
 
 		const table: Table = new TableBuilder().build();
 		const player: Player = new Player(table);
@@ -44,8 +46,8 @@ describe.only('The VpmController - VISUAL PINMAME COM OBJECT', () => {
 	});
 
 	afterEach(() => {
-		sandbox.restore();
-	});
+		sandbox.restore()
+	  });
 
 	//TODO this fails due wpc-emu module loader
 	it('should set and get GameName', () => {
@@ -137,9 +139,20 @@ describe.only('The VpmController - VISUAL PINMAME COM OBJECT', () => {
 		expect(setSwitchInputSpy.args[0]).to.deep.equal([ 11, false ]);
 	});
 
-	it('validate setFliptronicsInput is called with the correct settings, using 0 as input', () => {
+	it('validate setFliptronicsInput is called (F2), using 0 as input', () => {
 		vpmController.Switch[112] = 0;
-		expect(setSwitchInputSpy.args[0]).to.deep.equal([ 112, false ]);
+		expect(setFliptronicsInputSpy.args[0]).to.deep.equal([ 'F2', false ]);
+	});
+
+	it('validate setFliptronicsInput is called (F6), using 1 as input', () => {
+		vpmController.Switch[116] = 1;
+		expect(setFliptronicsInputSpy.args[0]).to.deep.equal([ 'F6', true ]);
+	});
+
+	it('validate setFliptronicsInput is called (F8), using false as input', () => {
+		// @ts-ignore
+		vpmController.Switch[118] = false;
+		expect(setFliptronicsInputSpy.args[0]).to.deep.equal([ 'F8', false ]);
 	});
 
 	it('validate setSwitchInput is called with the correct settings, using true as input', () => {

--- a/lib/scripting/objects/vpm-controller.ts
+++ b/lib/scripting/objects/vpm-controller.ts
@@ -44,39 +44,32 @@ export class VpmController {
 		this.emulator = new Emulator();
 		// TODO route this to the emu
 		this.Dip = this.createDipGetter();
+
 		this.Switch = this.createGetSetBooleanProxy('SWITCH',
-			(index) => this.emulator.getSwitchInput(index), (switchNr, value) => {
+			(index) => this.emulator.getSwitchInput(index),
+			(switchNr: number, value?: boolean) => {
 				if (switchNr < 89) {
 					return this.emulator.setSwitchInput(switchNr, value);
 				}
-
 				switch (switchNr) {
 					case 112:
-						return this.emulator.setFliptronicsInput('F2', value);
+						this.emulator.setFliptronicsInput('F2', value);
+						return true;
 					case 114:
-						return this.emulator.setFliptronicsInput('F4', value);
+						this.emulator.setFliptronicsInput('F4', value);
+						return true;
 					case 116:
-						return this.emulator.setFliptronicsInput('F6', value);
+						this.emulator.setFliptronicsInput('F6', value);
+						return true;
 					case 118:
-						return this.emulator.setFliptronicsInput('F8', value);
+						this.emulator.setFliptronicsInput('F8', value);
+						return true;
 				}
 				logger().error('INVALID_SWITCH_ID:', switchNr);
 				return false;
+			}
+		);
 
-/*
-Const swLRFlip = 112
-Const swLLFlip = 114
-Const swURFlip = 116
-Const swULFlip = 118
-
-    { id: 'F1', name: 'R FLIPPER EOS' },
-    { id: 'F2', name: 'R FLIPPER BUTTON' },
-    { id: 'F3', name: 'L FLIPPER EOS' },
-    { id: 'F4', name: 'L FLIPPER BUTTON' },
-    { id: 'F6', name: 'UR FLIPPER BUT' },
-    { id: 'F8', name: 'UL FLIPPER BUT' },
-*/
-			});
 		this.Lamp = this.createGetSetNumberProxy('LAMP',
 			(index) => this.emulator.getLampState(index), SET_NOP);
 		this.Solenoid = this.createGetSetNumberProxy('SOLENOID',
@@ -316,24 +309,24 @@ Const swULFlip = 118
 	}
 
 	private createGetSetBooleanProxy(name: string,
-		getFunction: (prop: number) => number,
-		setFunction: (prop: number, value?: boolean) => boolean,
+		getFunction: (switchNr: number) => number,
+		setFunction: (switchNr: number, value?: boolean) => boolean,
 	): { [index: number]: number } {
 		const handler = {
-			get: (target: {[ index: number ]: number}, prop: number): number => {
-				logger().debug('GET', name, {target, prop});
-				return getFunction(prop);
+			get: (target: {[ index: number ]: number}, switchNr: number): number => {
+				logger().debug('GET', name, {target, switchNr});
+				return getFunction(switchNr);
 			},
 
-			set: (target: {[ index: number ]: number}, prop: number | string, value: number | boolean): boolean => {
-				logger().debug('SET', name, {target, prop, value});
+			set: (target: {[ index: number ]: number}, switchNr: number | string, value?: number | boolean): boolean => {
+				logger().debug('SET', name, {target, switchNr, value});
 				if (value === 1 || value === true) {
-					return setFunction(parseInt(prop.toString(), 10), true);
+					return setFunction(parseInt(switchNr.toString(), 10), true);
 				}
 				if (value === 0 || value === false) {
-					return setFunction(parseInt(prop.toString(), 10), false);
+					return setFunction(parseInt(switchNr.toString(), 10), false);
 				}
-				return setFunction(parseInt(prop.toString(), 10));
+				return setFunction(parseInt(switchNr.toString(), 10));
 			},
 		};
 		return new Proxy<{ [index: number ]: number; }>({}, handler);

--- a/lib/scripting/objects/vpm-controller.ts
+++ b/lib/scripting/objects/vpm-controller.ts
@@ -45,7 +45,38 @@ export class VpmController {
 		// TODO route this to the emu
 		this.Dip = this.createDipGetter();
 		this.Switch = this.createGetSetBooleanProxy('SWITCH',
-			(index) => this.emulator.getSwitchInput(index), (switchNr, value) => this.emulator.setSwitchInput(switchNr, value));
+			(index) => this.emulator.getSwitchInput(index), (switchNr, value) => {
+				if (switchNr < 89) {
+					return this.emulator.setSwitchInput(switchNr, value);
+				}
+
+				switch (switchNr) {
+					case 112:
+						return this.emulator.setFliptronicsInput('F2', value);
+					case 114:
+						return this.emulator.setFliptronicsInput('F4', value);
+					case 116:
+						return this.emulator.setFliptronicsInput('F6', value);
+					case 118:
+						return this.emulator.setFliptronicsInput('F8', value);
+				}
+				logger().error('INVALID_SWITCH_ID:', switchNr);
+				return false;
+
+/*
+Const swLRFlip = 112
+Const swLLFlip = 114
+Const swURFlip = 116
+Const swULFlip = 118
+
+    { id: 'F1', name: 'R FLIPPER EOS' },
+    { id: 'F2', name: 'R FLIPPER BUTTON' },
+    { id: 'F3', name: 'L FLIPPER EOS' },
+    { id: 'F4', name: 'L FLIPPER BUTTON' },
+    { id: 'F6', name: 'UR FLIPPER BUT' },
+    { id: 'F8', name: 'UL FLIPPER BUT' },
+*/
+			});
 		this.Lamp = this.createGetSetNumberProxy('LAMP',
 			(index) => this.emulator.getLampState(index), SET_NOP);
 		this.Solenoid = this.createGetSetNumberProxy('SOLENOID',

--- a/lib/scripting/objects/vpm-controller.ts
+++ b/lib/scripting/objects/vpm-controller.ts
@@ -67,7 +67,7 @@ export class VpmController {
 				}
 				logger().error('INVALID_SWITCH_ID:', switchNr);
 				return false;
-			}
+			},
 		);
 
 		this.Lamp = this.createGetSetNumberProxy('LAMP',

--- a/package-lock.json
+++ b/package-lock.json
@@ -4721,9 +4721,9 @@
 			"dev": true
 		},
 		"wpc-emu": {
-			"version": "0.34.2",
-			"resolved": "https://registry.npmjs.org/wpc-emu/-/wpc-emu-0.34.2.tgz",
-			"integrity": "sha512-4BMWTuaxKsZLl39Dj59ir2SvDdiTIX3eeBOa21SyUWa4EaQkxFMruu8lpf77d7lYWMyolHf1axDitDkByu+JXQ==",
+			"version": "0.34.3",
+			"resolved": "https://registry.npmjs.org/wpc-emu/-/wpc-emu-0.34.3.tgz",
+			"integrity": "sha512-MEJ9MZVSI2yD3h64C9tyCSO014vxqH0kmTJpUpZ8XKsxVSonti1mYj/siXnnvPnp0o9ItQgdsyB0XQGzuVfu3w==",
 			"requires": {
 				"debug": "^4.1.1"
 			},

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
 		"sharp": "0.23.2",
 		"text-encoding": "^0.7.0",
 		"three": "^0.110.0",
-		"wpc-emu": "^0.34.2"
+		"wpc-emu": "^0.34.3"
 	},
 	"devDependencies": {
 		"@types/chai": "4.2.4",


### PR DESCRIPTION
Proper support and map fliptronics support.

looks like the visual pinmame interface mapps fliptronics flipper inputs as regular Switch calls - at least that is what I vound in the WPC-vbs script.

this pr implements fliptronics support - which was not working before. also bumped wpc-emu version to set fliptronics switch to a defined state (on/off)