### PR TITLE
github action should fail

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,6 +20,6 @@ jobs:
     - name: npm install, build, and test
       run: |
         npm ci
-        npm test
+        npm run ci
       env:
         CI: true

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,6 +20,6 @@ jobs:
     - name: npm install, build, and test
       run: |
         npm ci
-        npm run ci
+        npm test
       env:
         CI: true

--- a/lib/emu/wpc-emu.spec.ts
+++ b/lib/emu/wpc-emu.spec.ts
@@ -228,4 +228,10 @@ class MockWpcEmulator implements WpcEmuApi.Emulator {
 	public version(): string {
 		throw new Error('Method not implemented.');
 	}
+	public setDipSwitchByte(dipSwitch: number): void {
+		throw new Error('Method not implemented.');
+	}
+	public getDipSwitchByte(): number {
+		throw new Error('Method not implemented.');
+	}
 }

--- a/package.json
+++ b/package.json
@@ -38,10 +38,9 @@
 		"build:declarations": "tsc --module es2015 --outDir ./dist/esm --declaration true --allowJs false",
 		"build:watch": "npm run compile && npm run build:cp && tsc --watch --module es2015 --outDir ./dist/esm",
 		"build:cp": "cp -r res dist/esm && cp -r res dist/cjs",
-		"ci": "npm run compile && npx mocha",
 		"compile": "nearleyc lib/scripting/vbscript.ne -o lib/scripting/vbscript.ts",
 		"lint": "tslint --format stylish --project ./tsconfig.json --config ./lib/tslint.json",
-		"test": "npm run compile && nyc mocha"
+		"test": "npm run compile && nyc npx mocha"
 	},
 	"dependencies": {
 		"buffer": "5.4.3",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"build:declarations": "tsc --module es2015 --outDir ./dist/esm --declaration true --allowJs false",
 		"build:watch": "npm run compile && npm run build:cp && tsc --watch --module es2015 --outDir ./dist/esm",
 		"build:cp": "cp -r res dist/esm && cp -r res dist/cjs",
+		"ci": "npm run compile && npx mocha",
 		"compile": "nearleyc lib/scripting/vbscript.ne -o lib/scripting/vbscript.ts",
 		"lint": "tslint --format stylish --project ./tsconfig.json --config ./lib/tslint.json",
 		"test": "npm run compile && nyc mocha"

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,5 @@
 --require ts-node/register
+--require esm
 --bail
 --color
 --timeout 10000

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,6 +1,6 @@
 --require ts-node/register
---require esm
---sourcemap
+--bail
+--color
 --timeout 10000
 --file test/setup.ts
 lib/**/*.spec.ts


### PR DESCRIPTION
npx mocha works (aka fails), while npm t not (Aka passes when it should fail)

this pr fixes this, also text output is not scrambled anymore when test fails.

see https://github.com/vpdb/vpx-js/commit/69543e593cc524941298237a2638dc435e8cf833/checks?check_suite_id=311529829 for a failed pipeline run