### PR TITLE
Increase coverage threshold

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,11 @@
 coverage:
   round: up
-  range: 70..95
-  precision: 1
+  range: 50..95
+  precision: 2
+  status:
+    project:
+      default:
+        threshold: 0.2%
+    patch:
+      default:
+        threshold: 0.2%


### PR DESCRIPTION
We often get failed builds because the tests have some random factor (physics have that), and thus different code gets tested, resulting in 0.01% coverage decrease and thus failing. This should solve it.