### PR TITLE
remove threejs compile warning

### DIFF
--- a/lib/gltf/gltf-exporter.ts
+++ b/lib/gltf/gltf-exporter.ts
@@ -44,7 +44,6 @@ import {
 	NearestMipMapLinearFilter,
 	NearestMipMapNearestFilter,
 	Object3D,
-	PixelFormat,
 	PropertyBinding,
 	RepeatWrapping,
 	Scene,
@@ -746,11 +745,10 @@ export class GLTFExporter {
 	/**
 	 * Process image
 	 * @param  image image to process
-	 * @param  format of the image (e.g. RGBFormat, RGBAFormat etc)
 	 * @param  flipY before writing out the image
 	 * @return Index of the processed texture in the "images" array
 	 */
-	private processImage(image: NodeImage, format: PixelFormat, flipY: boolean) {
+	private processImage(image: NodeImage, flipY: boolean) {
 
 		const mimeType = image.getMimeType();
 		if (!this.outputJSON.images) {
@@ -835,7 +833,7 @@ export class GLTFExporter {
 
 		const gltfTexture = {
 			sampler: this.processSampler(map),
-			source: this.processImage(map.image, map.format, map.flipY),
+			source: this.processImage(map.image, map.flipY),
 		};
 		this.outputJSON.textures.push(gltfTexture);
 		const index = this.outputJSON.textures.length - 1;

--- a/lib/refs.browser.ts
+++ b/lib/refs.browser.ts
@@ -24,7 +24,7 @@ export { now } from './util/time.browser';
 export {
 	Object3D, Mesh, Box3, Scene, AnimationClip, KeyframeTrack, PropertyBinding, Camera, ClampToEdgeWrapping,
 	DoubleSide, InterpolateDiscrete, InterpolateLinear, LinearFilter, LinearMipMapLinearFilter, LinearMipMapNearestFilter,
-	MirroredRepeatWrapping, NearestFilter, NearestMipMapLinearFilter, NearestMipMapNearestFilter, PixelFormat,
+	MirroredRepeatWrapping, NearestFilter, NearestMipMapLinearFilter, NearestMipMapNearestFilter,
 	RepeatWrapping, TriangleFanDrawMode, TriangleStripDrawMode, BufferAttribute, BufferGeometry, Geometry,
 	InterleavedBufferAttribute, Light, Material, Color, Matrix4, Vector3, Bone, Texture, Math,
 	PointLight, Group, MeshStandardMaterial, Face3, Matrix3, Vector2, Path, Shape, ExtrudeBufferGeometry,

--- a/lib/refs.node.ts
+++ b/lib/refs.node.ts
@@ -26,7 +26,7 @@ export { getTextFile } from './scripting/vbs-scripts.node';
 export {
 	Object3D, Mesh, Box3, Scene, AnimationClip, KeyframeTrack, PropertyBinding, Camera, ClampToEdgeWrapping,
 	DoubleSide, InterpolateDiscrete, InterpolateLinear, LinearFilter, LinearMipMapLinearFilter, LinearMipMapNearestFilter,
-	MirroredRepeatWrapping, NearestFilter, NearestMipMapLinearFilter, NearestMipMapNearestFilter, PixelFormat,
+	MirroredRepeatWrapping, NearestFilter, NearestMipMapLinearFilter, NearestMipMapNearestFilter,
 	RepeatWrapping, TriangleFanDrawMode, TriangleStripDrawMode, BufferAttribute, BufferGeometry, Geometry,
 	InterleavedBufferAttribute, Light, Material, Color, Matrix4, Vector3, Bone, Texture, Math,
 	PointLight, Group, MeshStandardMaterial, Face3, Matrix3, Vector2, Path, Shape, ExtrudeBufferGeometry,

--- a/lib/render/threejs/vendor/EXRLoader.d.ts
+++ b/lib/render/threejs/vendor/EXRLoader.d.ts
@@ -1,11 +1,10 @@
-import { DataTextureLoader, LoadingManager, PixelFormat, TextureDataType } from '../../../refs.node';
+import { DataTextureLoader, LoadingManager, TextureDataType } from '../../../refs.node';
 
 export interface EXR {
 	header: object;
 	width: number;
 	height: number;
 	data: Float32Array;
-	format: PixelFormat;
 	type: TextureDataType;
 }
 

--- a/lib/render/threejs/vendor/RGBELoader.d.ts
+++ b/lib/render/threejs/vendor/RGBELoader.d.ts
@@ -1,4 +1,4 @@
-import { DataTextureLoader, LoadingManager, PixelFormat, TextureDataType } from '../../../refs.node';
+import { DataTextureLoader, LoadingManager, TextureDataType } from '../../../refs.node';
 
 export interface RGBE {
 	width: number;
@@ -7,7 +7,6 @@ export interface RGBE {
 	header: string;
 	gamma: number;
 	exposure: number;
-	format: PixelFormat;
 	type: TextureDataType;
 }
 


### PR DESCRIPTION
Disclaimer: I don't know what I'm doing ;)

But I assume due a threejs bump, we don't need those exports anymore. Also there is more warnings:

```
WARNING in ../vpx-js/dist/esm/lib/refs.browser.js 23:0-927
"export 'TextureDataType' was not found in 'three'
 @ ../vpx-js/dist/esm/lib/index.js
 @ ./src/loader.js
 @ ./src/index.js
```

So this is step 1 of n