### PR TITLE
Make ActiveX objects case-insensitive

### DIFF
--- a/lib/scripting/objects/index.ts
+++ b/lib/scripting/objects/index.ts
@@ -19,17 +19,30 @@
 
 import { Player } from '../../game/player';
 import { ERR } from '../stdlib/err';
+import { VbsProxyHandler } from '../vbs-proxy-handler';
 import { Dictionary } from './dictionary';
 import { FileSystemObject } from './file-system-object';
 import { VpmController } from './vpm-controller';
 import { WshShell } from './wsh-shell';
 
-export function getObject(name: string, player: Player): any {
+export function getObject<T>(name: string, player: Player): T | void {
+
 	switch (name.toLowerCase()) {
-		case 'scripting.dictionary': return new Dictionary();
-		case 'scripting.filesystemobject': return new FileSystemObject();
-		case 'vpinmame.controller': return new VpmController(player);
-		case 'wscript.shell': return new WshShell();
+		case 'scripting.dictionary':
+			const dictionary = new Dictionary();
+			return new Proxy(dictionary, new VbsProxyHandler(dictionary, Dictionary.prototype));
+
+		case 'scripting.filesystemobject':
+			const fso = new FileSystemObject();
+			return new Proxy(fso, new VbsProxyHandler(fso, FileSystemObject.prototype));
+
+		case 'vpinmame.controller':
+			const vpc = new VpmController(player);
+			return new Proxy(vpc, new VbsProxyHandler(vpc, VpmController.prototype));
+
+		case 'wscript.shell':
+			const wss = new WshShell();
+			return new Proxy(wss, new VbsProxyHandler(wss, WshShell.prototype));
 	}
 	ERR.Raise(429, undefined, "ActiveX component can't create object");
 }

--- a/lib/scripting/objects/vbs-to-wpcemu.spec.ts
+++ b/lib/scripting/objects/vbs-to-wpcemu.spec.ts
@@ -35,7 +35,7 @@ describe('VpmController integration test', () => {
 		sandbox.restore();
 	});
 
-	function setupPlayerTable(vbs) {
+	function setupPlayerTable(vbs: string) {
 		const scope = {};
 		const table = new TableBuilder().withTableScript(vbs).build('Table1');
 		new Player(table).init(scope);

--- a/lib/scripting/objects/vpm-controller.ts
+++ b/lib/scripting/objects/vpm-controller.ts
@@ -76,9 +76,6 @@ export class VpmController {
 				return true;
 			},
 		);
-		// See https://github.com/vpdb/vpx-js/issues/163
-		this.DIP = this.Dip;
-
 		this.Lamp = this.createGetSetNumberProxy('LAMP',
 			(index) => this.emulator.getLampState(index), SET_NOP);
 		this.Solenoid = this.createGetSetNumberProxy('SOLENOID',

--- a/lib/scripting/objects/vpm-controller.ts
+++ b/lib/scripting/objects/vpm-controller.ts
@@ -34,7 +34,6 @@ export class VpmController {
 	private splashInfoLine: string = '';
 	private readonly player: Player;
 	public readonly Dip: { [index: number]: number };
-	public readonly DIP: { [index: number]: number };
 	public readonly Switch: { [index: number]: number };
 	public readonly Lamp: { [index: number]: number };
 	public readonly Solenoid: { [index: number]: number };

--- a/lib/scripting/transpiler.ts
+++ b/lib/scripting/transpiler.ts
@@ -34,6 +34,7 @@ import { ReferenceTransformer } from './transformer/reference-transformer';
 import { ScopeTransformer } from './transformer/scope-transformer';
 import { WrapTransformer } from './transformer/wrap-transformer';
 import { VBSHelper } from './vbs-helper';
+import { VbsProxyHandler } from './vbs-proxy-handler';
 import vbsGrammar from './vbscript';
 
 //self.escodegen = require('escodegen');
@@ -86,7 +87,7 @@ export class Transpiler {
 
 		// tslint:disable-next-line:no-eval
 		eval('//@ sourceURL=tablescript.js\n' + js);
-		play(new Proxy(globalScope, new ScopeHandler()), this.itemApis, this.enumApis, this.globalApi, this.stdlib, new VBSHelper(this), this.player);
+		play(new Proxy(globalScope, new VbsProxyHandler()), this.itemApis, this.enumApis, this.globalApi, this.stdlib, new VBSHelper(this), this.player);
 	}
 
 	private parse(vbs: string): Program {
@@ -102,34 +103,5 @@ export class Transpiler {
 
 	private generate(ast: Program): string {
 		return generate(ast);
-	}
-}
-
-class ScopeHandler implements ProxyHandler<any> {
-
-	// tslint:disable-next-line:variable-name
-	private readonly __props: { [key: string]: string | number | symbol } = {};
-
-	public get(target: any, name: string | number | symbol, receiver: any): any {
-		const normName = typeof name === 'string' ? name.toLowerCase() : name.toString();
-		let realName = name;
-		if (!this.__props[normName]) {
-			this.__props[normName] = realName;
-		} else {
-			realName = this.__props[normName];
-		}
-		return target[realName];
-	}
-
-	public set(target: any, name: string | number | symbol, value: any, receiver: any): boolean {
-		const normName = typeof name === 'string' ? name.toLowerCase() : name.toString();
-		let realName = name;
-		if (!this.__props[normName]) {
-			this.__props[normName] = realName;
-		} else {
-			realName = this.__props[normName];
-		}
-		target[realName] = value;
-		return true;
 	}
 }

--- a/lib/scripting/vbs-proxy-handler.spec.ts
+++ b/lib/scripting/vbs-proxy-handler.spec.ts
@@ -1,0 +1,64 @@
+/*
+ * VPDB - Virtual Pinball Database
+ * Copyright (C) 2019 freezy <freezy@vpdb.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import * as chai from 'chai';
+import { expect } from 'chai';
+import { Player, Table } from '..';
+import { TableBuilder } from '../../test/table-builder';
+import { getObject } from './objects';
+
+/* tslint:disable:no-unused-expression no-string-literal */
+chai.use(require('sinon-chai'));
+describe('The VBScript proxy handler', () => {
+
+	const table: Table = new TableBuilder().build();
+	const player: Player = new Player(table);
+
+	it('should execute a case-insensitive function', () => {
+		const d = getObject<any>('Scripting.Dictionary', player);
+		d.Add('myKey1', 'myValue1');
+		d.add('myKey2', 'myValue2');
+		d.ADD('myKey3', 'myValue3');
+
+		expect(d.Item['myKey1']).to.equal('myValue1');
+		expect(d.Item['myKey2']).to.equal('myValue2');
+		expect(d.Item['myKey3']).to.equal('myValue3');
+	});
+
+	it('should get a case insensitive property', () => {
+		const wss = getObject<any>('WScript.Shell', player);
+		expect(wss.CurrentDirectory).to.equal('.');
+		expect(wss.CURRENTdirectory).to.equal('.');
+		expect(wss.cuRRenTdIreCtoRY).to.equal('.');
+	});
+
+	it('should set a case insensitive property', () => {
+		const wss = getObject<any>('WScript.Shell', player);
+
+		wss.CurrentDirectory = '/';
+		expect(wss.CurrentDirectory).to.equal('/');
+
+		wss.currentDIRECTORY = '/foo';
+		expect(wss.CurrentDirectory).to.equal('/foo');
+
+		wss.cuRRenTdIreCtoRY = '/bar';
+		expect(wss.CurrentDirectory).to.equal('/bar');
+	});
+
+});

--- a/lib/scripting/vbs-proxy-handler.ts
+++ b/lib/scripting/vbs-proxy-handler.ts
@@ -1,0 +1,73 @@
+/*
+ * VPDB - Virtual Pinball Database
+ * Copyright (C) 2019 freezy <freezy@vpdb.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/**
+ * A proxy handler that provides case-insensitive access to
+ * properties and functions.
+ */
+export class VbsProxyHandler implements ProxyHandler<any> {
+
+	// tslint:disable-next-line:variable-name
+	private readonly __names: { [key: string]: string | number | symbol } = {};
+
+	/**
+	 * Creates the handler. Pass in prototype and object instance if available.
+	 *
+	 * Object instance will index all currently set properties, while the
+	 * prototype also includes method names.
+	 *
+	 * @param obj Object instance
+	 * @param proto Prototype of object instance
+	 */
+	constructor(obj?: any, proto?: any) {
+		if (proto) {
+			for (const name of Object.getOwnPropertyNames(proto)) {
+				this.__names[name.toLowerCase()] = name;
+			}
+		}
+		if (obj) {
+			for (const name of Object.getOwnPropertyNames(obj)) {
+				this.__names[name.toLowerCase()] = name;
+			}
+		}
+	}
+
+	public get(target: any, name: string | number | symbol, receiver: any): any {
+		const normName = typeof name === 'string' ? name.toLowerCase() : name.toString();
+		let realName = name;
+		if (!this.__names[normName]) {
+			this.__names[normName] = realName;
+		} else {
+			realName = this.__names[normName];
+		}
+		return target[realName];
+	}
+
+	public set(target: any, name: string | number | symbol, value: any, receiver: any): boolean {
+		const normName = typeof name === 'string' ? name.toLowerCase() : name.toString();
+		let realName = name;
+		if (!this.__names[normName]) {
+			this.__names[normName] = realName;
+		} else {
+			realName = this.__names[normName];
+		}
+		target[realName] = value;
+		return true;
+	}
+}


### PR DESCRIPTION
This PR wraps all objects created by VBScript's `GetObject` function into a wrapper that makes their properties case insensitive.

It's the same approach already used in the former `ScopeProxy`, which is now replaced by a new, more generic class, that allows instantiation with an existing object to read it's initial properties.

See #163.
