### PR TITLE
Make textures load without warnings

### DIFF
--- a/lib/render/threejs/three-texture-loader-browser.ts
+++ b/lib/render/threejs/three-texture-loader-browser.ts
@@ -82,7 +82,7 @@ function getMimeType(data: Buffer, ext: string): string | null {
 
 async function load(mimeType: string, objectUrl: string): Promise<ThreeTexture> {
 	if (mimeType === 'application/octet-stream') {
-		return await loadHdrTexture(objectUrl);
+		return loadHdrTexture(objectUrl);
 	}
 	return loadLdrTexture(objectUrl);
 }

--- a/lib/render/threejs/three-texture-loader-browser.ts
+++ b/lib/render/threejs/three-texture-loader-browser.ts
@@ -41,14 +41,14 @@ export class ThreeTextureLoaderBrowser implements ITextureLoader<ThreeTexture> {
 		if (!imageMap[key]) {
 			throw new Error('Unknown local texture "' + key + '".');
 		}
-		return Promise.resolve(new TextureLoader().load(imageMap[key]));
+		return new TextureLoader().load(imageMap[key]);
 	}
 
 	public async loadRawTexture(name: string, data: Buffer, width: number, height: number): Promise<ThreeTexture> {
 		const texture = new DataTexture(data, width, height, RGBAFormat);
 		texture.flipY = true;
 		texture.needsUpdate = true;
-		return Promise.resolve(texture);
+		return texture;
 	}
 
 	public async loadTexture(name: string, ext: string, data: Buffer): Promise<ThreeTexture> {
@@ -61,7 +61,7 @@ export class ThreeTextureLoaderBrowser implements ITextureLoader<ThreeTexture> {
 		texture.name = `texture:${name}`;
 		texture.needsUpdate = true;
 		texture.anisotropy = 4;
-		return Promise.resolve(texture);
+		return texture;
 	}
 }
 
@@ -87,11 +87,18 @@ async function load(mimeType: string, objectUrl: string): Promise<ThreeTexture> 
 	return Promise.resolve(loadLdrTexture(objectUrl));
 }
 
-function loadLdrTexture(objectUrl: string): ThreeTexture {
-	const texture = new ThreeTexture();
-	texture.image = new Image();
-	texture.image.src = objectUrl;
-	return texture;
+async function loadLdrTexture(objectUrl: string): ThreeTexture {
+	console.log('loadLdrTexture', objectUrl);
+    return new Promise((resolve, reject) => {
+		const texture = new ThreeTexture();
+		texture.image = new Image();
+		texture.image.addEventListener('load', () => resolve(texture));
+		texture.image.addEventListener('error', () => {
+		  reject(new Error(`Failed to load image's URL: ${objectUrl}`));
+		});
+		texture.image.src = objectUrl;
+	  });
+
 }
 
 async function loadHdrTexture(objectUrl: string): Promise<ThreeTexture> {

--- a/lib/render/threejs/three-texture-loader-browser.ts
+++ b/lib/render/threejs/three-texture-loader-browser.ts
@@ -88,14 +88,11 @@ async function load(mimeType: string, objectUrl: string): Promise<ThreeTexture> 
 }
 
 async function loadLdrTexture(objectUrl: string): Promise<ThreeTexture> {
-	console.log('loadLdrTexture', objectUrl);
     return new Promise((resolve, reject) => {
 		const texture = new ThreeTexture();
 		texture.image = new Image();
 		texture.image.addEventListener('load', () => resolve(texture));
-		texture.image.addEventListener('error', () => {
-		  reject(new Error(`Failed to load image's URL: ${objectUrl}`));
-		});
+		texture.image.addEventListener('error', reject);
 		texture.image.src = objectUrl;
 	  });
 

--- a/lib/render/threejs/three-texture-loader-browser.ts
+++ b/lib/render/threejs/three-texture-loader-browser.ts
@@ -84,10 +84,10 @@ async function load(mimeType: string, objectUrl: string): Promise<ThreeTexture> 
 	if (mimeType === 'application/octet-stream') {
 		return await loadHdrTexture(objectUrl);
 	}
-	return Promise.resolve(loadLdrTexture(objectUrl));
+	return loadLdrTexture(objectUrl);
 }
 
-async function loadLdrTexture(objectUrl: string): ThreeTexture {
+async function loadLdrTexture(objectUrl: string): Promise<ThreeTexture> {
 	console.log('loadLdrTexture', objectUrl);
     return new Promise((resolve, reject) => {
 		const texture = new ThreeTexture();

--- a/lib/render/threejs/three-texture-loader-browser.ts
+++ b/lib/render/threejs/three-texture-loader-browser.ts
@@ -88,13 +88,13 @@ async function load(mimeType: string, objectUrl: string): Promise<ThreeTexture> 
 }
 
 async function loadLdrTexture(objectUrl: string): Promise<ThreeTexture> {
-    return new Promise((resolve, reject) => {
+	return new Promise((resolve, reject) => {
 		const texture = new ThreeTexture();
 		texture.image = new Image();
 		texture.image.addEventListener('load', () => resolve(texture));
 		texture.image.addEventListener('error', reject);
 		texture.image.src = objectUrl;
-	  });
+	});
 
 }
 


### PR DESCRIPTION
Make sure loadLdrTexture returns only if image has been loaded, this was not the case and could work or not.

I also removed some unneeded promises.

Using this branch I was not able to trigger the issue again. 

Note: before it worked as well, but loading time was higher if we picked up the "bad path" (see description in #175) and we already draw the playfield black (only lamps were visible), then after some seconds the playfield appeared.

The lightning issue is still not fixed, will address this in a separate PR